### PR TITLE
Increase top padding for mobile status bar clearance

### DIFF
--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -8,7 +8,7 @@
   margin: 0 auto;
   min-height: 100vh;
   position: relative;
-  padding-top: calc(env(safe-area-inset-top, 0px) + 32px);
+  padding-top: calc(env(safe-area-inset-top, 0px) + 56px);
 }
 
 .main-content {


### PR DESCRIPTION
Increased safe area padding from 32px to 56px to provide better
clearance and prevent the phone menu bar from covering content.