### PR TITLE
Add GitHub Actions workflow for database migrations

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -1,0 +1,39 @@
+name: Apply Database Migrations
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'migrations/**'
+
+jobs:
+  migrate:
+    name: Apply D1 Migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply migrations to production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations apply workout-db --remote
+
+      - name: List applied migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler d1 migrations list workout-db --remote


### PR DESCRIPTION
This workflow automatically applies D1 database migrations to production
when migrations are added or modified. It can also be triggered manually.

This fixes the issue where exercises weren't showing up after deployment
because the personal_records table migration wasn't applied.