### PR TITLE
Automate release tagging on merge to main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: write
@@ -16,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for tags
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -29,16 +29,33 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Set version
+      - name: Determine next version
+        id: version
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-            npm pkg set version=$VERSION
+          # Get the latest tag
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            # No tags exist, start with v1.0.0
+            NEW_VERSION="1.0.0"
           else
-            # Use commit SHA for branch builds
-            VERSION="0.0.0-${GITHUB_SHA::7}"
-            npm pkg set version=$VERSION
+            # Extract version without 'v' prefix
+            VERSION=${LATEST_TAG#v}
+
+            # Split version into major.minor.patch
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+            # Increment patch version
+            PATCH=$((PATCH + 1))
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           fi
+
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Next version: v$NEW_VERSION"
+
+      - name: Set version in package.json
+        run: npm pkg set version=${{ steps.version.outputs.version }}
 
       - name: Install dependencies
         run: npm ci
@@ -60,24 +77,19 @@ jobs:
 
       - name: Rename APK with version
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION="0.0.0-${GITHUB_SHA::7}"
-          fi
+          VERSION="${{ steps.version.outputs.tag }}"
           mv android/app/build/outputs/apk/release/app-release.apk android/app/build/outputs/apk/release/workout-tracker-${VERSION}.apk
 
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin ${{ steps.version.outputs.tag }}
+
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
           files: android/app/build/outputs/apk/release/*.apk
           generate_release_notes: true
-
-      - name: Upload APK artifact
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: actions/upload-artifact@v4
-        with:
-          name: workout-tracker-apk
-          path: android/app/build/outputs/apk/release/*.apk
-          retention-days: 30


### PR DESCRIPTION
- Modified android.yml workflow to automatically create tags and releases
- Workflow now determines next patch version from latest tag
- Creates and pushes new tag after building APK
- Creates GitHub release with APK and auto-generated notes
- Removed tag trigger to avoid duplicate workflow runs

When a PR is merged to main, the workflow will:
1. Fetch all tags and determine next version (e.g., v1.0.8 → v1.0.9)
2. Build the Android APK with the new version
3. Create and push the new tag
4. Create a GitHub release with the APK attached