### PR TITLE
Add visual feedback for auto-save during workouts

### DIFF
--- a/e2e/workout.spec.ts
+++ b/e2e/workout.spec.ts
@@ -250,6 +250,101 @@ test.describe('Workout Tracker', () => {
     });
     expect(secondHasGray).toBe(true);
   });
+
+  test('should show save feedback when adding a set during workout', async ({ page }) => {
+    // Start workout and add exercise
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await page.getByRole('button', { name: '+ Add Exercise' }).click();
+    await page.locator('#add-exercise-results').getByText('Bench Press', { exact: true }).click();
+
+    // Add a set
+    await page.getByRole('button', { name: '+ Add set' }).click();
+    await page.fill('input[placeholder="wt"]', '135');
+    await page.fill('input[placeholder="reps"]', '10');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Wait for auto-save to trigger (1.5s delay)
+    await page.waitForTimeout(1600);
+
+    // Toast should be visible
+    const toast = page.locator('#save-toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Saved');
+
+    // Toast should fade out after 2 seconds
+    await page.waitForTimeout(2500);
+    await expect(toast).not.toBeVisible();
+  });
+
+  test('should show save feedback when updating a set', async ({ page }) => {
+    // Start workout and add exercise with a set
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await page.getByRole('button', { name: '+ Add Exercise' }).click();
+    await page.locator('#add-exercise-results').getByText('Bench Press', { exact: true }).click();
+    await page.getByRole('button', { name: '+ Add set' }).click();
+    await page.fill('input[placeholder="wt"]', '135');
+    await page.fill('input[placeholder="reps"]', '10');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Wait for initial auto-save to complete
+    await page.waitForTimeout(2000);
+
+    // Update the weight
+    const weightInput = page.locator('input[type="number"]').first();
+    await weightInput.fill('145');
+    await weightInput.blur();
+
+    // Wait for auto-save to trigger
+    await page.waitForTimeout(1600);
+
+    // Toast should be visible
+    const toast = page.locator('#save-toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Saved');
+  });
+
+  test('should show save feedback when adding an exercise', async ({ page }) => {
+    // Start workout
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+
+    // Add an exercise
+    await page.getByRole('button', { name: '+ Add Exercise' }).click();
+    await page.locator('#add-exercise-results').getByText('Bench Press', { exact: true }).click();
+
+    // Wait for auto-save to trigger
+    await page.waitForTimeout(1600);
+
+    // Toast should be visible
+    const toast = page.locator('#save-toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Saved');
+  });
+
+  test('should show save feedback when toggling set completion', async ({ page }) => {
+    // Start workout and add exercise with a set
+    await page.getByRole('button', { name: 'Start Workout' }).click();
+    await page.getByRole('button', { name: '+ Add Exercise' }).click();
+    await page.locator('#add-exercise-results').getByText('Bench Press', { exact: true }).click();
+    await page.getByRole('button', { name: '+ Add set' }).click();
+    await page.fill('input[placeholder="wt"]', '135');
+    await page.fill('input[placeholder="reps"]', '10');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Wait for initial auto-save to complete and toast to disappear
+    await page.waitForTimeout(4000);
+
+    // Toggle set completion
+    const setCheckbox = page.locator('button').filter({ has: page.locator('svg circle') }).first();
+    await setCheckbox.click();
+
+    // Wait for auto-save to trigger
+    await page.waitForTimeout(1600);
+
+    // Toast should be visible
+    const toast = page.locator('#save-toast');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Saved');
+  });
 });
 
 test.describe('Authentication', () => {

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -47,6 +47,7 @@ let currentExerciseUnit: 'lbs' | 'kg' = 'lbs';
 let pendingDeleteWorkoutId: string | null = null;
 let autoSaveTimeout: ReturnType<typeof setTimeout> | null = null;
 let expandedNotes = new Set<string>(); // Track which notes are expanded (format: "exerciseIndex-setIndex")
+let toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
 // ==================== HELPERS ====================
 function getAllExercises(): Exercise[] {
@@ -95,6 +96,29 @@ function $input(id: string): HTMLInputElement {
 
 function $select(id: string): HTMLSelectElement {
   return document.getElementById(id) as unknown as HTMLSelectElement;
+}
+
+// Show a temporary toast notification
+function showToast(message: string = 'Saved'): void {
+  const toast = $('save-toast');
+
+  // Clear any existing timeout
+  if (toastTimeout) {
+    clearTimeout(toastTimeout);
+  }
+
+  // Update message and show toast
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  toast.style.opacity = '1';
+
+  // Hide after 2 seconds
+  toastTimeout = setTimeout(() => {
+    toast.style.opacity = '0';
+    setTimeout(() => {
+      toast.classList.add('hidden');
+    }, 300); // Wait for fade transition
+  }, 2000);
 }
 
 // Check if a set is a PR based on exercise name, weight, reps, and position
@@ -323,6 +347,9 @@ async function autoSaveWorkout(): Promise<void> {
     // Reload data to refresh history, but keep current workout active
     await loadData();
     console.log('Workout auto-saved');
+
+    // Show visual feedback
+    showToast('Saved');
   } catch (error) {
     console.error('Failed to auto-save workout:', error);
     // Silently fail - don't interrupt user's workflow with alerts

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -41,6 +41,11 @@
     </div>
 
     <div id="main-app" class="hidden">
+    <!-- Auto-save toast notification -->
+    <div id="save-toast" class="hidden fixed top-20 left-1/2 transform -translate-x-1/2 bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg z-50 transition-opacity duration-300">
+      Saved
+    </div>
+
     <div class="main-content">
 
       <!-- TAB: WORKOUT -->


### PR DESCRIPTION
When users make changes during a workout (adding/updating sets, adding exercises, etc.):
- A "Saved" toast notification now appears after the 1.5s auto-save completes
- Toast is positioned at the top-center of the screen
- Toast fades in, displays for 2 seconds, then fades out
- Multiple rapid changes reuse the same toast (clearing previous timeout)

Added comprehensive e2e tests covering:
- Save feedback when adding a set
- Save feedback when updating a set
- Save feedback when adding an exercise
- Save feedback when toggling set completion

This addresses the issue where PR #15 only added feedback for the manual "Save" button, but not for the auto-save functionality used during active workouts.