### PR TITLE
Fix login screen flash on page load for authenticated users

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -1245,12 +1245,18 @@ async function clearAllData(): Promise<void> {
 }
 
 // ==================== AUTH ====================
+function hideLoadingScreen(): void {
+  $('loading-screen').classList.add('hidden');
+}
+
 function showAuthScreen(): void {
+  hideLoadingScreen();
   $('auth-screen').classList.remove('hidden');
   $('main-app').classList.add('hidden');
 }
 
 function showMainApp(): void {
+  hideLoadingScreen();
   $('auth-screen').classList.add('hidden');
   $('main-app').classList.remove('hidden');
   if (currentUser) {
@@ -1342,13 +1348,15 @@ async function init(): Promise<void> {
 
   // Check if already authenticated
   if (api.isAuthenticated()) {
+    // Show main app immediately to avoid flash, verify token in background
+    showMainApp();
+
     try {
       currentUser = await api.getCurrentUser();
       await loadData();
-      showMainApp();
       renderAddExerciseList(getAllExercises());
     } catch {
-      // Token invalid or expired
+      // Token invalid or expired - switch back to auth screen
       api.logout();
       showAuthScreen();
     }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -10,8 +10,16 @@
 <body class="bg-gray-900 text-gray-100">
   <div class="phone-frame bg-gray-800">
 
+    <!-- LOADING SCREEN -->
+    <div id="loading-screen" class="flex items-center justify-center h-full">
+      <div class="text-center">
+        <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mb-4"></div>
+        <div class="text-gray-400">Loading...</div>
+      </div>
+    </div>
+
     <!-- AUTH SCREEN -->
-    <div id="auth-screen" class="p-4">
+    <div id="auth-screen" class="p-4 hidden">
       <div class="flex flex-col items-center justify-center py-12">
         <h1 class="text-2xl font-bold mb-8">Workout Tracker</h1>
 


### PR DESCRIPTION
The app previously showed a brief flash of the login screen when loading
for already-authenticated users. This happened because the HTML initially
displayed the auth screen while waiting for an async API call to verify
the token.

Changes:
- Add a loading screen that displays initially during app initialization
- Hide auth screen by default and show it only when needed
- Show main app immediately if a token exists in localStorage
- Verify token in background and only switch back to auth if invalid
- Add hideLoadingScreen() function to properly manage screen transitions

This provides a much smoother UX - authenticated users now see:
1. Brief loading spinner (during script load)
2. Main app appears immediately
3. No flash of login screen

For unauthenticated users:
1. Brief loading spinner
2. Auth screen appears

Token verification still happens in the background for security.