### PR TITLE
Start exercise categories collapsed when adding to workout

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -903,9 +903,8 @@ function renderAddExerciseCategories(): void {
     if (exercises.length === 0) return '';
 
     exercises = sortAddExercises(exercises);
-    // Auto-expand if this is a target category
     const isTargetCategory = targetCategories.includes(main.name as Category);
-    const isExpanded = expandedAddExerciseCategories.has(main.name) || isTargetCategory;
+    const isExpanded = expandedAddExerciseCategories.has(main.name);
 
     // Highlight target categories
     const categoryLabelClass = isTargetCategory


### PR DESCRIPTION
Categories no longer auto-expand based on target selection.
Target categories remain sorted to top with blue styling and badge.