### PR TITLE
Fix exercise categories not showing when adding to workout

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -1046,6 +1046,11 @@ function showAddExercise(): void {
   ($('add-exercise-search') as HTMLInputElement).value = '';
   addExerciseSort = { field: 'recent', asc: true };
   updateAddExerciseSortButtons();
+  // Reset category expansion state so all start collapsed
+  expandedAddExerciseCategories.clear();
+  // Reset search/categories visibility
+  $('add-exercise-categories').classList.remove('hidden');
+  $('add-exercise-search-results').classList.add('hidden');
   renderAddExerciseCategories();
   showWorkoutScreen('workout-add-exercise');
 }


### PR DESCRIPTION
Reset the expanded categories state and search/categories panel
visibility when opening the add exercise modal. Previously, if a
user searched for an exercise and selected one, the categories
panel would remain hidden when reopening the modal.