### PR TITLE
feat: add freeform notes to exercises in workouts

### DIFF
--- a/migrations/0007_add_notes_to_workout_exercises.sql
+++ b/migrations/0007_add_notes_to_workout_exercises.sql
@@ -1,0 +1,2 @@
+-- Add notes column to workout_exercises for freeform exercise-level notes
+ALTER TABLE workout_exercises ADD COLUMN notes TEXT;

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -4,6 +4,7 @@ import {
   createUser,
   createWorkout,
   getWorkout,
+  updateWorkout,
   createCustomExercise,
   updateCustomExercise,
   getAllCustomExercises,
@@ -575,5 +576,329 @@ describe('Exercise Rename Synchronization', () => {
     // Verify user 2's workout is NOT updated
     const updated2 = await getWorkout(env.DB, created2.id, user2.id);
     expect(updated2?.exercises[0].name).toBe('Shared Name');
+  });
+});
+
+describe('Exercise Notes', () => {
+  let userId: string;
+  const testUsername = 'testuser_notes';
+  const testPasswordHash = 'hash123';
+
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM users WHERE username = ?').bind(testUsername).run();
+    const user = await createUser(env.DB, testUsername, testPasswordHash);
+    userId = user.id;
+  });
+
+  it('should persist notes through createWorkout and return them in getWorkout', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Felt strong today, good form on all reps',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    expect(created.exercises[0].notes).toBe('Felt strong today, good form on all reps');
+
+    // Also verify via a fresh getWorkout call (not the returned object)
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.exercises[0].notes).toBe('Felt strong today, good form on all reps');
+  });
+
+  it('should handle exercises without notes (undefined)', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Squat',
+          sets: [
+            { weight: 225, reps: 5, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    // notes should be undefined, not null
+    expect(created.exercises[0].notes).toBeUndefined();
+
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched!.exercises[0].notes).toBeUndefined();
+  });
+
+  it('should handle exercises with explicitly null notes', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Deadlift',
+          notes: undefined,
+          sets: [
+            { weight: 315, reps: 3, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    // Should come back as undefined (not null) in the API response
+    expect(created.exercises[0].notes).toBeUndefined();
+  });
+
+  it('should preserve notes through updateWorkout', async () => {
+    // Create workout with notes
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Original note',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+    expect(created.exercises[0].notes).toBe('Original note');
+
+    // Update workout - change the note
+    const updateData: CreateWorkoutRequest = {
+      start_time: created.start_time,
+      end_time: created.end_time,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Updated note after review',
+          sets: [
+            { weight: 135, reps: 10, completed: true },
+            { weight: 155, reps: 8, completed: true }
+          ]
+        }
+      ]
+    };
+    const updated = await updateWorkout(env.DB, created.id, userId, updateData);
+
+    expect(updated).not.toBeNull();
+    expect(updated!.exercises[0].notes).toBe('Updated note after review');
+
+    // Verify with fresh fetch
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched!.exercises[0].notes).toBe('Updated note after review');
+  });
+
+  it('should allow removing notes via updateWorkout (set to undefined)', async () => {
+    // Create workout with notes
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Will remove this',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+    expect(created.exercises[0].notes).toBe('Will remove this');
+
+    // Update workout - remove note by omitting it
+    const updateData: CreateWorkoutRequest = {
+      start_time: created.start_time,
+      end_time: created.end_time,
+      exercises: [
+        {
+          name: 'Bench Press',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const updated = await updateWorkout(env.DB, created.id, userId, updateData);
+
+    expect(updated).not.toBeNull();
+    expect(updated!.exercises[0].notes).toBeUndefined();
+  });
+
+  it('should handle notes on multiple exercises independently', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Chest day main lift',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        },
+        {
+          name: 'Incline DB Press',
+          sets: [
+            { weight: 50, reps: 12, completed: true }
+          ]
+        },
+        {
+          name: 'Cable Fly',
+          notes: 'Squeeze at the top',
+          sets: [
+            { weight: 30, reps: 15, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    expect(created.exercises[0].notes).toBe('Chest day main lift');
+    expect(created.exercises[1].notes).toBeUndefined();
+    expect(created.exercises[2].notes).toBe('Squeeze at the top');
+  });
+
+  it('should handle empty string notes', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: '',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    // Empty string should be stored and returned (not converted to undefined)
+    // This tests whether the implementation treats '' differently from null/undefined
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    // Empty string is falsy but not null, so it depends on the ?? operator behavior
+    // '' ?? undefined === '' (nullish coalescing does NOT trigger on empty string)
+    expect(fetched!.exercises[0].notes).toBe('');
+  });
+
+  it('should handle very long notes', async () => {
+    const longNote = 'A'.repeat(5000);
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: longNote,
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    expect(created.exercises[0].notes).toBe(longNote);
+
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched!.exercises[0].notes).toBe(longNote);
+  });
+
+  it('should handle notes with special characters', async () => {
+    const specialNote = "Used Smith machine. Weight doesn't include bar.\nForm: 3-1-2 tempo.\tRest: 90s.\n\"PR attempt\" — failed at lockout (≥90% 1RM)";
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: specialNote,
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    expect(created.exercises[0].notes).toBe(specialNote);
+
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched!.exercises[0].notes).toBe(specialNote);
+  });
+
+  it('should not confuse exercise notes with set notes', async () => {
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Exercise-level note',
+          sets: [
+            { weight: 135, reps: 10, completed: true, note: 'Set-level note' }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+
+    // Exercise note and set note should be independent
+    expect(created.exercises[0].notes).toBe('Exercise-level note');
+    expect(created.exercises[0].sets[0].note).toBe('Set-level note');
+
+    const fetched = await getWorkout(env.DB, created.id, userId);
+    expect(fetched!.exercises[0].notes).toBe('Exercise-level note');
+    expect(fetched!.exercises[0].sets[0].note).toBe('Set-level note');
+  });
+
+  it('should preserve notes when adding notes to previously note-less exercise via update', async () => {
+    // Create workout without notes
+    const workout: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      end_time: Date.now() + 3600000,
+      exercises: [
+        {
+          name: 'Bench Press',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const created = await createWorkout(env.DB, userId, workout);
+    expect(created.exercises[0].notes).toBeUndefined();
+
+    // Update to add notes
+    const updateData: CreateWorkoutRequest = {
+      start_time: created.start_time,
+      end_time: created.end_time,
+      exercises: [
+        {
+          name: 'Bench Press',
+          notes: 'Added note after the fact',
+          sets: [
+            { weight: 135, reps: 10, completed: true }
+          ]
+        }
+      ]
+    };
+    const updated = await updateWorkout(env.DB, created.id, userId, updateData);
+
+    expect(updated).not.toBeNull();
+    expect(updated!.exercises[0].notes).toBe('Added note after the fact');
   });
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -153,6 +153,7 @@ async function getWorkoutExercises(db: D1Database, workoutId: string): Promise<W
       name: exRow.exercise_name,
       sets,
       completed: exRow.completed === 1,
+      notes: exRow.notes ?? undefined,
     });
   }
 
@@ -177,8 +178,8 @@ export async function createWorkout(db: D1Database, userId: string, data: Create
     const exId = generateId();
 
     await db
-      .prepare('INSERT INTO workout_exercises (id, workout_id, exercise_name, position, completed) VALUES (?, ?, ?, ?, ?)')
-      .bind(exId, id, ex.name, i, ex.completed ? 1 : 0)
+      .prepare('INSERT INTO workout_exercises (id, workout_id, exercise_name, position, completed, notes) VALUES (?, ?, ?, ?, ?, ?)')
+      .bind(exId, id, ex.name, i, ex.completed ? 1 : 0, ex.notes ?? null)
       .run();
 
     for (let j = 0; j < ex.sets.length; j++) {
@@ -227,8 +228,8 @@ export async function updateWorkout(db: D1Database, id: string, userId: string, 
     const exId = generateId();
 
     await db
-      .prepare('INSERT INTO workout_exercises (id, workout_id, exercise_name, position, completed) VALUES (?, ?, ?, ?, ?)')
-      .bind(exId, id, ex.name, i, ex.completed ? 1 : 0)
+      .prepare('INSERT INTO workout_exercises (id, workout_id, exercise_name, position, completed, notes) VALUES (?, ?, ?, ?, ?, ?)')
+      .bind(exId, id, ex.name, i, ex.completed ? 1 : 0, ex.notes ?? null)
       .run();
 
     for (let j = 0; j < ex.sets.length; j++) {

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS workout_exercises (
   exercise_name TEXT NOT NULL,
   position INTEGER NOT NULL,
   completed INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
   FOREIGN KEY (workout_id) REFERENCES workouts(id) ON DELETE CASCADE
 );
 

--- a/src/db/test-setup.ts
+++ b/src/db/test-setup.ts
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS workout_exercises (
   exercise_name TEXT NOT NULL,
   position INTEGER NOT NULL,
   completed INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
   FOREIGN KEY (workout_id) REFERENCES workouts(id) ON DELETE CASCADE
 );
 

--- a/src/frontend/api.ts
+++ b/src/frontend/api.ts
@@ -107,6 +107,7 @@ export interface WorkoutExercise {
   name: string;
   sets: Set[];
   completed?: boolean;
+  notes?: string;
 }
 
 export interface PersonalRecord {

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -221,6 +221,43 @@ function hidePRHistory(): void {
   modal.setAttribute('aria-hidden', 'true');
 }
 
+// Exercise notes modal
+let editingNotesExerciseIndex: number | null = null;
+
+function showExerciseNotes(exerciseIndex: number): void {
+  if (!state.currentWorkout) return;
+  const exercise = state.currentWorkout.exercises[exerciseIndex];
+  editingNotesExerciseIndex = exerciseIndex;
+
+  const modal = $('exercise-notes-modal');
+  const title = $('exercise-notes-title');
+  const textarea = $('exercise-notes-textarea') as HTMLTextAreaElement;
+
+  title.textContent = `${exercise.name} Notes`;
+  textarea.value = exercise.notes || '';
+
+  modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
+  textarea.focus();
+}
+
+function hideExerciseNotes(): void {
+  const modal = $('exercise-notes-modal');
+  modal.classList.add('hidden');
+  modal.setAttribute('aria-hidden', 'true');
+  editingNotesExerciseIndex = null;
+}
+
+function saveExerciseNotes(): void {
+  if (editingNotesExerciseIndex === null || !state.currentWorkout) return;
+  const textarea = $('exercise-notes-textarea') as HTMLTextAreaElement;
+  const notes = textarea.value.trim();
+  state.currentWorkout.exercises[editingNotesExerciseIndex].notes = notes || undefined;
+  hideExerciseNotes();
+  renderWorkout();
+  scheduleAutoSave();
+}
+
 // Check if a set is a PR based on exercise name, weight, reps, and position
 function calculateIsPR(exerciseName: string, weight: number, reps: number, exerciseIndex: number, setIndex: number): boolean {
   if (!state.currentWorkout) return false;
@@ -712,7 +749,12 @@ function renderWorkout(): void {
           </div>
         </div>
         ${setsHtml}
-        <div class="flex justify-end mt-2">
+        <div class="flex justify-between items-center mt-2">
+          <button onclick="app.showExerciseNotes(${i})" class="${ex.notes ? 'text-blue-400' : 'text-gray-500'} hover:text-blue-300 transition-colors" title="${ex.notes ? 'Edit notes' : 'Add notes'}">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+            </svg>
+          </button>
           <button onclick="app.showPRHistory('${ex.name.replace(/'/g, "\\'")}')" class="text-gray-500 hover:text-yellow-400 transition-colors" title="View PR history">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
@@ -2084,6 +2126,9 @@ async function init(): Promise<void> {
   toggleExerciseCompleted,
   showPRHistory,
   hidePRHistory,
+  showExerciseNotes,
+  hideExerciseNotes,
+  saveExerciseNotes,
   toggleSetCompleted,
   toggleSetMissed,
   toggleNoteField,

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -46,6 +46,27 @@
       Saved
     </div>
 
+    <!-- Exercise Notes Modal -->
+    <div id="exercise-notes-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center" aria-hidden="true">
+      <div class="absolute inset-0 bg-black/70" onclick="app.hideExerciseNotes()"></div>
+      <div class="relative bg-gray-800 rounded-lg shadow-xl max-w-sm w-full mx-4 max-h-[80vh] overflow-hidden">
+        <div class="flex justify-between items-center p-4 border-b border-gray-700">
+          <h2 class="text-lg font-semibold" id="exercise-notes-title">Exercise Notes</h2>
+          <button onclick="app.hideExerciseNotes()" class="text-gray-400 hover:text-white">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        </div>
+        <div class="p-4">
+          <textarea id="exercise-notes-textarea" rows="6" placeholder="Add notes for this exercise..." class="w-full bg-gray-700 border border-gray-600 rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-blue-500 resize-none"></textarea>
+          <div class="flex justify-end mt-3">
+            <button onclick="app.saveExerciseNotes()" class="bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded-lg text-sm">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- PR History Modal -->
     <div id="pr-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center" aria-hidden="true">
       <div class="absolute inset-0 bg-black/70" onclick="app.hidePRHistory()"></div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface WorkoutExercise {
   name: string;
   sets: Set[];
   completed?: boolean;
+  notes?: string;
 }
 
 export interface Workout {
@@ -69,6 +70,7 @@ export interface WorkoutExerciseRow {
   exercise_name: string;
   position: number;
   completed: number;
+  notes: string | null;
 }
 
 export interface SetRow {


### PR DESCRIPTION
## Summary
- Adds a notes icon (lower-left of each exercise card) that opens a modal for writing freeform notes per exercise
- Notes persist through auto-save and are stored in the `workout_exercises` table via new `notes TEXT` column
- Icon turns blue when notes exist, gray when empty

## Changes
- **Migration**: `0007_add_notes_to_workout_exercises.sql` adds `notes TEXT` column
- **Backend**: Types, DB queries, and schema updated to read/write exercise-level notes
- **Frontend**: Notes modal with textarea, icon button on exercise cards, auto-save integration
- **Tests**: 11 new test cases covering round-trip persistence, null/undefined handling, special characters, long notes, and independence from set-level notes

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (26/26 tests)
- [x] `npm run build:frontend` succeeds
- [ ] CI passes
- [ ] Manual test: add notes to exercise, verify persistence after page reload
- [ ] Manual test: verify notes icon turns blue when notes exist
- [ ] Manual test: verify notes survive editing a workout from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)