### PR TITLE
feat: real-time sync polling for external workout changes (EMI-354)

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -16,7 +16,7 @@ import {
   showAddSetForm, hideAddSetForm, saveSetInline, updateSet, deleteSet,
   showExerciseNotes, hideExerciseNotes, saveExerciseNotes,
   renderWorkout, scheduleAutoSave, editWorkout, resetWorkoutState,
-  refreshCurrentWorkout,
+  refreshCurrentWorkout, startSyncPolling, stopSyncPolling,
 } from './workout';
 import {
   showAddExercise, hideAddExercise, toggleAddExerciseSort, toggleAddExerciseCategory,
@@ -55,6 +55,12 @@ async function clearAllData(): Promise<void> {
       alert('Failed to clear data');
     }
   }
+}
+
+// ==================== LOGOUT ====================
+function handleLogout(): void {
+  stopSyncPolling();
+  logout();
 }
 
 // ==================== REFRESH HANDLER ====================
@@ -100,6 +106,7 @@ async function init(): Promise<void> {
 
   $('auth-form').addEventListener('submit', createAuthSubmitHandler(() => {
     showMainApp(handleRefresh);
+    startSyncPolling();
   }));
 
   if (api.isAuthenticated()) {
@@ -108,6 +115,7 @@ async function init(): Promise<void> {
       setCurrentUser(user);
       await loadData();
       showMainApp(handleRefresh);
+      startSyncPolling();
     } catch {
       api.logout();
       showAuthScreen();
@@ -183,7 +191,7 @@ async function init(): Promise<void> {
   clearAllData,
   showLoginForm,
   showRegisterForm,
-  logout,
+  logout: handleLogout,
   // Rest Timer
   startRestTimer,
   pauseRestTimer,

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -15,6 +15,9 @@ let autoSaveTimeout: ReturnType<typeof setTimeout> | null = null;
 let editingWorkoutUpdatedAt: number | null = null;
 let autoSaveConflictRetries = 0;
 const MAX_AUTO_SAVE_CONFLICT_RETRIES = 3;
+let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+let isSyncPolling = false;
+let isAutoSaving = false;
 let expandedNotes = new Set<string>();
 let selectedTargetCategories = new Set<MuscleGroup>();
 let isEditingCategories = false;
@@ -190,6 +193,7 @@ export function scheduleAutoSave(): void {
   }
 
   autoSaveTimeout = setTimeout(() => {
+    autoSaveTimeout = null;
     autoSaveWorkout();
   }, 1500);
 }
@@ -199,6 +203,7 @@ async function autoSaveWorkout(): Promise<void> {
     return;
   }
 
+  isAutoSaving = true;
   try {
     const workoutData: CreateWorkoutRequest & { updated_at?: number } = {
       start_time: state.currentWorkout.startTime,
@@ -240,6 +245,8 @@ async function autoSaveWorkout(): Promise<void> {
     } else {
       console.error('Failed to auto-save workout:', error);
     }
+  } finally {
+    isAutoSaving = false;
   }
 }
 
@@ -642,6 +649,66 @@ function switchTabDirect(tabName: string): void {
   });
   $('nav-' + tabName).classList.remove('text-[#888888]');
   $('nav-' + tabName).classList.add('text-[#FF0000]');
+}
+
+// ==================== SYNC POLLING ====================
+export function startSyncPolling(): void {
+  stopSyncPolling();
+  pollIntervalId = setInterval(syncPoll, 5000);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+}
+
+export function stopSyncPolling(): void {
+  if (pollIntervalId !== null) {
+    clearInterval(pollIntervalId);
+    pollIntervalId = null;
+  }
+  isSyncPolling = false;
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
+}
+
+function handleVisibilityChange(): void {
+  if (document.hidden) {
+    if (pollIntervalId !== null) {
+      clearInterval(pollIntervalId);
+      pollIntervalId = null;
+    }
+  } else {
+    if (pollIntervalId === null) {
+      pollIntervalId = setInterval(syncPoll, 5000);
+      syncPoll();
+    }
+  }
+}
+
+async function syncPoll(): Promise<void> {
+  if (!state.editingWorkoutId || autoSaveTimeout !== null || isAutoSaving || isSyncPolling) {
+    return;
+  }
+
+  isSyncPolling = true;
+  try {
+    const workout = await api.getWorkout(state.editingWorkoutId);
+
+    if (workout.updated_at === editingWorkoutUpdatedAt) {
+      return;
+    }
+
+    mergeServerWorkout(workout);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      state.currentWorkout = null;
+      state.editingWorkoutId = null;
+      editingWorkoutUpdatedAt = null;
+      autoSaveConflictRetries = 0;
+      isEditingFromHistory = false;
+      expandedNotes.clear();
+      showWorkoutScreen('workout-empty');
+    }
+    // Silently ignore network errors
+  } finally {
+    isSyncPolling = false;
+  }
 }
 
 // ==================== RESET HELPERS ====================


### PR DESCRIPTION
## Summary
- Polls the server every 5 seconds for the active workout's state
- When an external client (e.g., OpenClaw trainer) modifies the workout via the API, changes are automatically merged into local state using the existing `mergeServerWorkout` conflict-resolution logic
- Pauses polling when auto-save is pending or in-flight to prevent race conditions
- Pauses/resumes on tab visibility changes to save bandwidth and battery
- Handles external workout deletion gracefully (404 → clears local state)
- Stops polling on logout, starts on login

## Test plan
- [ ] Open app with an active workout, verify no errors in console from polling
- [ ] Use API/MCP to modify the current workout externally, verify changes appear within ~5 seconds
- [ ] Edit workout locally, verify auto-save still works correctly
- [ ] Switch to another browser tab and back, verify polling resumes
- [ ] Delete workout externally via API, verify app shows empty workout screen
- [ ] Log out and back in, verify polling restarts cleanly
- [ ] Test on Android via Capacitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)