### PR TITLE
feat: swipeable tabs for exercise PRs + last workout

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -4,7 +4,7 @@ import { $, showToast } from './helpers';
 import { loadData } from './data';
 import { switchTab, onTabSwitch, showWorkoutScreen } from './nav';
 import { startRestTimer, pauseRestTimer, stopRestTimer } from './rest-timer';
-import { showPRHistory, hidePRHistory } from './pr-calc';
+import { showPRHistory, hidePRHistory, switchPRTab } from './pr-calc';
 import { showLoginForm, showRegisterForm, showAuthScreen, showMainApp, createAuthSubmitHandler, logout, getCurrentUser, setCurrentUser } from './auth';
 import {
   startWorkout,
@@ -161,6 +161,7 @@ async function init(): Promise<void> {
   toggleExerciseCompleted,
   showPRHistory,
   hidePRHistory,
+  switchPRTab,
   showExerciseNotes,
   hideExerciseNotes,
   saveExerciseNotes,

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -109,14 +109,30 @@
       <div class="absolute inset-0 bg-black/80" onclick="app.hidePRHistory()"></div>
       <div class="relative bg-swiss-card border border-swiss-border rounded-sm max-w-sm w-full mx-4 max-h-[80vh] overflow-hidden">
         <div class="flex justify-between items-center p-4 border-b border-swiss-border">
-          <h2 class="text-sm font-bold uppercase tracking-[0.2em]" id="pr-modal-title">PR History</h2>
+          <h2 class="text-sm font-bold uppercase tracking-[0.2em]" id="pr-modal-title">Exercise</h2>
           <button onclick="app.hidePRHistory()" class="text-swiss-text-secondary hover:text-white">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
             </svg>
           </button>
         </div>
-        <div id="pr-modal-content" class="p-4 overflow-y-auto max-h-[60vh]"></div>
+        <!-- Tab headers -->
+        <div class="flex border-b border-swiss-border" id="pr-modal-tabs">
+          <button id="pr-tab-prs" class="flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-swiss-red text-white" onclick="app.switchPRTab(0)">PRs</button>
+          <button id="pr-tab-last" class="flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-transparent text-swiss-text-secondary" onclick="app.switchPRTab(1)">Last Workout</button>
+        </div>
+        <!-- Swipe container -->
+        <div id="pr-modal-swipe" class="overflow-hidden">
+          <div id="pr-modal-slider" class="flex transition-transform duration-200 ease-out" style="transform: translateX(0%)">
+            <div id="pr-panel-prs" class="w-full flex-shrink-0 p-4 overflow-y-auto max-h-[55vh]"></div>
+            <div id="pr-panel-last" class="w-full flex-shrink-0 p-4 overflow-y-auto max-h-[55vh]"></div>
+          </div>
+        </div>
+        <!-- Dot indicators -->
+        <div class="flex justify-center gap-2 py-2 border-t border-swiss-border" id="pr-modal-dots">
+          <span id="pr-dot-0" class="w-2 h-2 rounded-full bg-swiss-red"></span>
+          <span id="pr-dot-1" class="w-2 h-2 rounded-full bg-[#444]"></span>
+        </div>
       </div>
     </div>
 

--- a/src/frontend/pr-calc.ts
+++ b/src/frontend/pr-calc.ts
@@ -1,5 +1,5 @@
 import { state } from './state';
-import { $, getExerciseUnit } from './helpers';
+import { $, getExerciseUnit, formatDate } from './helpers';
 
 export function calculateIsPR(exerciseName: string, weight: number, reps: number, exerciseIndex: number, setIndex: number): boolean {
   if (!state.currentWorkout) return false;
@@ -67,10 +67,71 @@ export function recalculateAllPRs(): void {
   }
 }
 
-export function showPRHistory(exerciseName: string): void {
-  const modal = $('pr-modal');
-  const title = $('pr-modal-title');
-  const content = $('pr-modal-content');
+// ==================== TAB STATE ====================
+let currentTab = 0;
+
+export function switchPRTab(index: number): void {
+  currentTab = index;
+  const slider = $('pr-modal-slider');
+  slider.style.transform = `translateX(-${index * 100}%)`;
+
+  // Update tab header styles
+  const tabPRs = $('pr-tab-prs');
+  const tabLast = $('pr-tab-last');
+
+  if (index === 0) {
+    tabPRs.className = 'flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-swiss-red text-white';
+    tabLast.className = 'flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-transparent text-swiss-text-secondary';
+  } else {
+    tabPRs.className = 'flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-transparent text-swiss-text-secondary';
+    tabLast.className = 'flex-1 py-2 text-xs font-bold uppercase tracking-[0.15em] text-center border-b-2 border-swiss-red text-white';
+  }
+
+  // Update dot indicators
+  $('pr-dot-0').className = `w-2 h-2 rounded-full ${index === 0 ? 'bg-swiss-red' : 'bg-[#444]'}`;
+  $('pr-dot-1').className = `w-2 h-2 rounded-full ${index === 1 ? 'bg-swiss-red' : 'bg-[#444]'}`;
+}
+
+// ==================== SWIPE HANDLING ====================
+function initSwipe(): void {
+  const swipeContainer = $('pr-modal-swipe');
+  let startX = 0;
+  let startY = 0;
+  let isDragging = false;
+
+  swipeContainer.addEventListener('touchstart', (e: TouchEvent) => {
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+    isDragging = true;
+  }, { passive: true });
+
+  swipeContainer.addEventListener('touchmove', (_e: TouchEvent) => {
+    // We track but don't preventDefault to allow vertical scroll
+  }, { passive: true });
+
+  swipeContainer.addEventListener('touchend', (e: TouchEvent) => {
+    if (!isDragging) return;
+    isDragging = false;
+
+    const endX = e.changedTouches[0].clientX;
+    const endY = e.changedTouches[0].clientY;
+    const diffX = endX - startX;
+    const diffY = endY - startY;
+
+    // Only trigger if horizontal movement exceeds vertical and threshold
+    if (Math.abs(diffX) > 50 && Math.abs(diffX) > Math.abs(diffY)) {
+      if (diffX < 0 && currentTab === 0) {
+        switchPRTab(1);
+      } else if (diffX > 0 && currentTab === 1) {
+        switchPRTab(0);
+      }
+    }
+  }, { passive: true });
+}
+
+// ==================== PR TABLE RENDERING ====================
+function renderPRsPanel(exerciseName: string): void {
+  const panel = $('pr-panel-prs');
 
   const prs = state.allPRs
     .filter(pr => pr.exercise_name === exerciseName)
@@ -82,7 +143,6 @@ export function showPRHistory(exerciseName: string): void {
       if (exercise.name !== exerciseName) continue;
       for (const set of exercise.sets) {
         if (!set.isPR || set.missed === true || set.completed !== true) continue;
-        // Check if this PR already exists in server data (avoid duplicates)
         const alreadyRecorded = prs.some(pr =>
           pr.weight === set.weight && pr.reps === set.reps &&
           pr.workout_id === state.editingWorkoutId
@@ -103,10 +163,8 @@ export function showPRHistory(exerciseName: string): void {
     }
   }
 
-  title.textContent = `${exerciseName} PRs`;
-
   if (prs.length === 0) {
-    content.innerHTML = `
+    panel.innerHTML = `
       <div class="text-center text-[#888888] py-8">
         <p>No PRs recorded yet.</p>
         <p class="text-sm mt-2">PRs are tracked when you beat your best reps at a given weight.</p>
@@ -124,7 +182,7 @@ export function showPRHistory(exerciseName: string): void {
     const sortedWeights = [...prsByWeight.keys()].sort((a, b) => b - a);
     const unit = getExerciseUnit(exerciseName);
 
-    content.innerHTML = `
+    panel.innerHTML = `
       <table class="w-full text-sm font-mono">
         <thead>
           <tr class="text-[#888888] text-left text-xs uppercase tracking-wider">
@@ -152,6 +210,92 @@ export function showPRHistory(exerciseName: string): void {
         </tbody>
       </table>
     `;
+  }
+}
+
+// ==================== LAST WORKOUT RENDERING ====================
+function renderLastWorkoutPanel(exerciseName: string): void {
+  const panel = $('pr-panel-last');
+  const unit = getExerciseUnit(exerciseName);
+
+  // Find last workout containing this exercise, skipping the current one
+  let lastWorkout = null;
+  let lastExercise = null;
+
+  for (const workout of state.history) {
+    // Skip the workout currently being edited
+    if (state.editingWorkoutId && workout.id === state.editingWorkoutId) continue;
+    // Skip workouts at or after current workout start time
+    if (state.currentWorkout && workout.start_time >= state.currentWorkout.startTime) continue;
+
+    const ex = workout.exercises.find(e => e.name === exerciseName);
+    if (ex && ex.sets.length > 0) {
+      lastWorkout = workout;
+      lastExercise = ex;
+      break;
+    }
+  }
+
+  if (!lastWorkout || !lastExercise) {
+    panel.innerHTML = `
+      <div class="text-center text-[#888888] py-8">
+        <p>No previous workout found.</p>
+        <p class="text-sm mt-2">Complete a workout with this exercise to see history here.</p>
+      </div>
+    `;
+    return;
+  }
+
+  const dateStr = formatDate(lastWorkout.start_time);
+
+  panel.innerHTML = `
+    <div class="text-xs text-[#888888] uppercase tracking-wider mb-3">${dateStr}</div>
+    <table class="w-full text-sm font-mono">
+      <thead>
+        <tr class="text-[#888888] text-left text-xs uppercase tracking-wider">
+          <th class="pb-2">Set</th>
+          <th class="pb-2">Weight</th>
+          <th class="pb-2">Reps</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-[#2A2A2A]">
+        ${lastExercise.sets.map((set, i) => {
+          const missed = set.missed === true;
+          const rowClass = missed ? 'opacity-40 line-through' : '';
+          return `
+            <tr class="${rowClass}">
+              <td class="py-2">${i + 1}</td>
+              <td class="py-2 font-medium">${set.weight} ${unit}</td>
+              <td class="py-2">${set.reps}</td>
+            </tr>
+          `;
+        }).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+// ==================== MODAL SHOW/HIDE ====================
+let swipeInitialized = false;
+
+export function showPRHistory(exerciseName: string): void {
+  const modal = $('pr-modal');
+  const title = $('pr-modal-title');
+
+  title.textContent = exerciseName;
+
+  // Reset to first tab
+  currentTab = 0;
+  switchPRTab(0);
+
+  // Render both panels
+  renderPRsPanel(exerciseName);
+  renderLastWorkoutPanel(exerciseName);
+
+  // Initialize swipe once
+  if (!swipeInitialized) {
+    initSwipe();
+    swipeInitialized = true;
   }
 
   modal.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Transforms the exercise PR modal into a two-tab swipeable panel
- **Tab 1 - PRs**: Existing PR history table (unchanged)
- **Tab 2 - Last Workout**: Shows sets/reps from the most recent previous workout with that exercise, with date header and missed sets dimmed
- Horizontal swipe gestures on mobile (50px threshold, ignores vertical scrolling)
- Clickable tab headers + dot indicators for current tab
- Title now shows just the exercise name since the modal covers more than PRs

## Test plan
- [ ] Open a workout, tap the chart icon on an exercise
- [ ] Verify PRs tab shows correctly (same as before)
- [ ] Swipe left or tap "Last Workout" tab — verify it shows sets from the last time you did this exercise
- [ ] Swipe back or tap "PRs" tab — verify it returns
- [ ] Test with an exercise that has no previous workout history — should show empty state
- [ ] Test on mobile — swipe gesture should feel natural and not interfere with vertical scroll
- [ ] Verify dot indicators and tab header styles update on switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)