### PR TITLE
docs: tighten worktree bootstrap and completion rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ If there is a conflict, follow the stricter rule.
 - Use non-destructive git commands only (no force push, no hard reset, no destructive checkout).
 - All changes must go through a pull request; do not push directly to `main`.
 - CI is the source of truth; if local and CI results differ, follow CI and fix until it passes.
+- YOUR WORK IS NOT DONE AND YOU MUST NOT STOP UNTIL THE PR IS MERGED.
+
+## Worktree Bootstrap (REQUIRED)
+
+- Create a new worktree from `origin/main` with a unique branch name before editing.
+- In the new worktree, run `npm install` before any checks.
+- Run `npm run build:frontend` once in a fresh worktree before `npm test` (Vitest expects `dist/` to exist).
+- If a previous worktree path was removed manually, run `git worktree prune` before creating a new one.
 
 ## API and Data Operations (MANDATORY)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Instructions
+
+This file defines the minimum required rules for automated coding agents.
+`CLAUDE.md` contains full project context and detailed procedures.
+If there is a conflict, follow the stricter rule.
+
+## Non-Negotiable Rules
+
+- Do all implementation work in a dedicated git worktree; never work directly in the primary checkout.
+- Every feature and bug fix must include test coverage.
+- Run `npm run typecheck`, `npm test`, and `npm run test:e2e` before finalizing changes.
+- Use non-destructive git commands only (no force push, no hard reset, no destructive checkout).
+- All changes must go through a pull request; do not push directly to `main`.
+- CI is the source of truth; if local and CI results differ, follow CI and fix until it passes.
+
+## API and Data Operations (MANDATORY)
+
+- Prefer API-driven workflows for functional verification; avoid manual database edits unless the task explicitly requires a migration or targeted repair.
+- For schema changes, add a new migration in `migrations/` and keep `src/db/schema.sql` in sync.
+- Keep API contracts and shared schemas aligned (`src/types.ts`, `src/shared/schemas.ts`, route handlers, and DB queries).
+
+### Required Auth for Non-Interactive Flows
+
+Wrangler and protected API operations require the appropriate credentials.
+
+```powershell
+$env:CLOUDFLARE_API_TOKEN="<token>"
+```
+
+For machine/API key access, use the app's `wt_` API keys where required.
+
+## Reference
+
+- Read `CLAUDE.md` before substantial changes for architecture, testing matrix, deployment, and workflow details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,3 +278,9 @@ Create `.mcp.json` in the project root (gitignored — contains API key):
 - Main app tsconfig excludes `src/mcp/` — the MCP server has its own build
 - Build output: `dist-mcp/` (gitignored)
 - **Never use `console.log` in MCP server code** — stdout is the JSON-RPC channel; use `console.error` instead
+
+## Knowledge Graph (Agent-MCP)
+
+After significant changes (new features, architecture decisions, schema changes), save context to Agent-MCP using `update_project_context`. Use the key prefix `exercise-tracker-thingy/` (e.g., `exercise-tracker-thingy/architecture`).
+
+Update existing entries when information changes. Create new keys for new topics. This ensures any agent in any session can retrieve project context via `ask_project_rag`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,30 @@ git worktree add ../exercise-tracker-<feature-name> -b claude/<feature-name> ori
 # Work in the worktree
 cd ../exercise-tracker-<feature-name>
 npm install
+npm run build:frontend
 
 # When done, clean up
 git worktree remove ../exercise-tracker-<feature-name>
 ```
 
 Worktree naming: `../exercise-tracker-<descriptive-name>` (e.g., `../exercise-tracker-add-rest-timer`)
+
+If setup fails due to stale metadata or existing branch/path:
+
+```bash
+# Clean stale worktree metadata (safe, non-destructive)
+git worktree prune
+
+# If branch already exists, reuse it without -b
+git worktree add ../exercise-tracker-<feature-name> claude/<feature-name>
+```
+
+Fresh worktree bootstrap checklist:
+1. `git fetch origin`
+2. `git worktree add ../exercise-tracker-<feature-name> -b claude/<feature-name> origin/main`
+3. `cd ../exercise-tracker-<feature-name>`
+4. `npm install`
+5. `npm run build:frontend` (required before `npm test` in a fresh worktree)
 
 ## Project Overview
 

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -296,6 +296,7 @@ export function renderWorkout(): void {
     return;
   }
 
+  recalculateAllPRs();
   const exercises = state.currentWorkout.exercises;
   const exerciseCount = exercises.length;
 
@@ -464,7 +465,6 @@ export function toggleExerciseCompleted(index: number): void {
 export function toggleSetCompleted(exerciseIndex: number, setIndex: number): void {
   const set = state.currentWorkout!.exercises[exerciseIndex].sets[setIndex];
   set.completed = !set.completed;
-  recalculateAllPRs();
   renderWorkout();
   scheduleAutoSave();
 }
@@ -472,7 +472,6 @@ export function toggleSetCompleted(exerciseIndex: number, setIndex: number): voi
 export function toggleSetMissed(exerciseIndex: number, setIndex: number): void {
   const set = state.currentWorkout!.exercises[exerciseIndex].sets[setIndex];
   set.missed = !set.missed;
-  recalculateAllPRs();
   renderWorkout();
   scheduleAutoSave();
 }
@@ -513,7 +512,6 @@ export function saveSetInline(exerciseIndex: number): void {
   if (note) set.note = note;
 
   state.currentWorkout!.exercises[exerciseIndex].sets.push(set);
-  recalculateAllPRs();
   renderWorkout();
   scheduleAutoSave();
 }
@@ -529,11 +527,9 @@ export function updateSet(exerciseIndex: number, setIndex: number, field: string
     renderWorkout();
   } else if (field === 'weight') {
     set.weight = parseFloat(value) || 0;
-    recalculateAllPRs();
     renderWorkout();
   } else if (field === 'reps') {
     set.reps = parseInt(value) || 0;
-    recalculateAllPRs();
     renderWorkout();
   }
   scheduleAutoSave();
@@ -541,7 +537,6 @@ export function updateSet(exerciseIndex: number, setIndex: number, field: string
 
 export function deleteSet(exerciseIndex: number, setIndex: number): void {
   state.currentWorkout!.exercises[exerciseIndex].sets.splice(setIndex, 1);
-  recalculateAllPRs();
   renderWorkout();
   scheduleAutoSave();
 }


### PR DESCRIPTION
## Summary
- add required worktree bootstrap checklist in AGENTS.md
- document fresh-worktree setup + stale worktree recovery in CLAUDE.md
- add explicit completion rule requiring work to continue until PR merge

## Testing
- not run (documentation-only changes)