### PR TITLE
fix: recalculate PR stars when weight/reps values change

### DIFF
--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -335,7 +335,7 @@ export function renderWorkout(): void {
                 <input type="number" value="${set.weight}" oninput="app.updateSet(${i}, ${si}, 'weight', this.value)" class="w-16 bg-[#1A1A1A] border border-[#2A2A2A] rounded-sm px-2 py-1 text-center text-sm font-mono focus:outline-none focus:border-[#FF0000] text-white ${isSetCompleted ? 'opacity-50' : ''}">
                 <span class="text-[#888888] ${isSetCompleted ? 'line-through' : ''}">x</span>
                 <input type="number" value="${set.reps}" oninput="app.updateSet(${i}, ${si}, 'reps', this.value)" class="w-14 bg-[#1A1A1A] border border-[#2A2A2A] rounded-sm px-2 py-1 text-center text-sm font-mono focus:outline-none focus:border-[#FF0000] text-white ${isSetCompleted ? 'opacity-50' : ''}">
-                ${set.isPR ? (set.completed && !isSetMissed ? '<span class="text-[#FFD700] text-lg">★</span>' : '<span class="text-[#FFD700] text-lg opacity-40">★</span>') : ''}
+                <span id="star-${i}-${si}">${set.isPR ? (set.completed && !isSetMissed ? '<span class="text-[#FFD700] text-lg">★</span>' : '<span class="text-[#FFD700] text-lg opacity-40">★</span>') : ''}</span>
                 <button onclick="app.toggleSetMissed(${i}, ${si})" class="flex-shrink-0 hover:opacity-80 transition-opacity" title="${isSetMissed ? 'Mark as not missed' : 'Mark as missed'}">
                   ${missIcon}
                 </button>
@@ -531,7 +531,32 @@ export function updateSet(exerciseIndex: number, setIndex: number, field: string
   } else if (field === 'reps') {
     set.reps = parseInt(value) || 0;
   }
+  if (field === 'weight' || field === 'reps') {
+    recalculateAllPRs();
+    updateStarIndicators();
+  }
   scheduleAutoSave();
+}
+
+function updateStarIndicators(): void {
+  if (!state.currentWorkout) return;
+  const exercises = state.currentWorkout.exercises;
+  for (let i = 0; i < exercises.length; i++) {
+    const ex = exercises[i];
+    for (let si = 0; si < ex.sets.length; si++) {
+      const set = ex.sets[si];
+      const starEl = document.getElementById('star-' + i + '-' + si);
+      if (!starEl) continue;
+      const isSetMissed = set.missed || false;
+      if (set.isPR) {
+        starEl.innerHTML = set.completed && !isSetMissed
+          ? '<span class="text-[#FFD700] text-lg">\u2605</span>'
+          : '<span class="text-[#FFD700] text-lg opacity-40">\u2605</span>';
+      } else {
+        starEl.innerHTML = '';
+      }
+    }
+  }
 }
 
 export function deleteSet(exerciseIndex: number, setIndex: number): void {

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -538,6 +538,8 @@ export function updateSet(exerciseIndex: number, setIndex: number, field: string
   scheduleAutoSave();
 }
 
+// star-{i}-{si} IDs use array indices, which is safe because any set
+// reordering (add/remove/splice) triggers a full renderWorkout() re-render.
 function updateStarIndicators(): void {
   if (!state.currentWorkout) return;
   const exercises = state.currentWorkout.exercises;
@@ -550,8 +552,8 @@ function updateStarIndicators(): void {
       const isSetMissed = set.missed || false;
       if (set.isPR) {
         starEl.innerHTML = set.completed && !isSetMissed
-          ? '<span class="text-[#FFD700] text-lg">\u2605</span>'
-          : '<span class="text-[#FFD700] text-lg opacity-40">\u2605</span>';
+          ? '<span class="text-[#FFD700] text-lg">★</span>'
+          : '<span class="text-[#FFD700] text-lg opacity-40">★</span>';
       } else {
         starEl.innerHTML = '';
       }


### PR DESCRIPTION
## Context

PR (Personal Record) stars were not appearing for planned sets after editing weight or reps values in the workout form. Stars would only show up after toggling the "failed" flag, because that code path triggered a full re-render. The root cause was that `updateSet()` updated state and scheduled an auto-save but never recalculated PR flags or updated star indicators in the DOM.

## Summary

After weight or reps changes, `updateSet()` now calls `recalculateAllPRs()` to recompute `isPR` flags across all sets in the workout, then performs a targeted DOM update of just the star indicator spans. This avoids a full `renderWorkout()` call that would cause input focus loss and cursor jumping while the user is actively typing.

Each star position now has an `id` attribute (`star-{exerciseIndex}-{setIndex}`) so the update function can find and patch just those elements without touching the rest of the DOM.

Related: #92 (prevented weight/reps inputs from reverting during editing), #95 (fixed duplicate ghost PR stars)

Regards, -Claude