### PR TITLE
feat: audit log for db mutations

### DIFF
--- a/migrations/0012_add_audit_log.sql
+++ b/migrations/0012_add_audit_log.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS audit_log (
+  id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL,
+  user_id TEXT,
+  auth_method TEXT NOT NULL,
+  api_key_name TEXT,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT,
+  route TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_user_id_created_at ON audit_log(user_id, created_at DESC);

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,6 +3,7 @@ import type { Env, RegisterRequest, LoginRequest, AuthResponse } from '../types'
 import { hashPassword, verifyPassword, createToken } from '../auth';
 import { getUserByUsername, createUser, getUserById, createApiKey } from '../db/queries';
 import { authMiddleware } from '../middleware/auth';
+import { logAudit } from '../db/audit';
 
 const auth = new Hono<{ Bindings: Env }>();
 
@@ -34,6 +35,8 @@ auth.post('/register', async (c) => {
 
   // Generate token
   const token = await createToken(user.id, c.env.JWT_SECRET);
+
+  await logAudit(c, { action: 'create', entity_type: 'user', entity_id: user.id });
 
   const response: AuthResponse = { token, user };
   return c.json(response, 201);
@@ -93,6 +96,7 @@ auth.post('/api-keys', authMiddleware, async (c) => {
   }
 
   const { id, key } = await createApiKey(c.env.DB, userId, body.name);
+  await logAudit(c, { action: 'create', entity_type: 'api_key', entity_id: id });
   return c.json({ id, key, name: body.name }, 201);
 });
 

--- a/src/api/exercises.ts
+++ b/src/api/exercises.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Env, CreateExerciseRequest } from '../types';
 import * as queries from '../db/queries';
 import { authMiddleware } from '../middleware/auth';
+import { logAudit } from '../db/audit';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -55,6 +56,7 @@ app.post('/', async (c) => {
 
   try {
     const exercise = await queries.createCustomExercise(c.env.DB, userId, body);
+    await logAudit(c, { action: 'create', entity_type: 'custom_exercise', entity_id: exercise.id });
     return c.json(exercise, 201);
   } catch (err) {
     if (err instanceof queries.IdConflictError) {
@@ -74,6 +76,7 @@ app.post('/:id/restore', async (c) => {
     return c.json({ error: 'Deleted exercise not found' }, 404);
   }
 
+  await logAudit(c, { action: 'update', entity_type: 'custom_exercise', entity_id: id });
   return c.json({ success: true });
 });
 
@@ -93,6 +96,7 @@ app.put('/:id', async (c) => {
     return c.json({ error: 'Exercise not found' }, 404);
   }
 
+  await logAudit(c, { action: 'update', entity_type: 'custom_exercise', entity_id: exercise.id });
   return c.json(exercise);
 });
 
@@ -128,6 +132,7 @@ app.patch('/:id/settings', async (c) => {
   if (!result) {
     return c.json({ error: 'Exercise not found' }, 404);
   }
+  await logAudit(c, { action: 'update', entity_type: 'custom_exercise', entity_id: result.id });
   return c.json(result);
 });
 
@@ -141,6 +146,7 @@ app.delete('/:id', async (c) => {
     return c.json({ error: 'Exercise not found' }, 404);
   }
 
+  await logAudit(c, { action: 'delete', entity_type: 'custom_exercise', entity_id: id });
   return c.json({ success: true });
 });
 

--- a/src/api/workouts.ts
+++ b/src/api/workouts.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Env, CreateWorkoutRequest } from '../types';
 import * as queries from '../db/queries';
 import { authMiddleware } from '../middleware/auth';
+import { logAudit } from '../db/audit';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -48,6 +49,7 @@ app.post('/', async (c) => {
 
   try {
     const workout = await queries.createWorkout(c.env.DB, userId, body);
+    await logAudit(c, { action: 'create', entity_type: 'workout', entity_id: workout.id });
     return c.json(workout, 201);
   } catch (err) {
     if (err instanceof queries.IdConflictError) {
@@ -77,6 +79,7 @@ app.put('/:id', async (c) => {
     return c.json({ error: 'Conflict', current: result.current }, 409);
   }
 
+  await logAudit(c, { action: 'update', entity_type: 'workout', entity_id: result.workout.id });
   return c.json(result.workout);
 });
 
@@ -90,6 +93,7 @@ app.delete('/:id', async (c) => {
     return c.json({ error: 'Workout not found' }, 404);
   }
 
+  await logAudit(c, { action: 'delete', entity_type: 'workout', entity_id: id });
   return c.json({ success: true });
 });
 

--- a/src/db/audit.ts
+++ b/src/db/audit.ts
@@ -1,0 +1,44 @@
+import type { Context } from 'hono';
+import type { Env } from '../types';
+import type { AuthMethod } from '../middleware/auth';
+
+export interface LogAuditArgs {
+  action: string; // 'create' | 'update' | 'delete'
+  entity_type: string; // 'workout' | 'custom_exercise' | 'user' | 'api_key'
+  entity_id?: string | null;
+}
+
+/**
+ * Write a single row to audit_log describing a DB-altering event.
+ *
+ * Pulls actor info (user_id, auth_method, api_key_name) from the Hono context
+ * and captures the route from the request. Throws on failure — audit writes
+ * are intentionally not swallowed so a broken pipeline is visible.
+ */
+export async function logAudit(
+  c: Context<{ Bindings: Env }>,
+  { action, entity_type, entity_id }: LogAuditArgs
+): Promise<void> {
+  const userId = (c.get('userId') as string | undefined) ?? null;
+  const authMethod = (c.get('authMethod') as AuthMethod | undefined) ?? 'unauthenticated';
+  const apiKeyName = (c.get('apiKeyName') as string | null | undefined) ?? null;
+
+  const route = `${c.req.method} ${c.req.routePath}`;
+
+  await c.env.DB
+    .prepare(
+      'INSERT INTO audit_log (id, created_at, user_id, auth_method, api_key_name, action, entity_type, entity_id, route) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    )
+    .bind(
+      crypto.randomUUID(),
+      Date.now(),
+      userId,
+      authMethod,
+      apiKeyName,
+      action,
+      entity_type,
+      entity_id ?? null,
+      route
+    )
+    .run();
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -680,16 +680,16 @@ export async function createApiKey(db: D1Database, userId: string, name: string)
   return { id, key };
 }
 
-export async function getUserByApiKey(db: D1Database, key: string): Promise<string | null> {
+export async function getUserByApiKey(db: D1Database, key: string): Promise<{ user_id: string; name: string } | null> {
   // Hash the provided key
   const encoder = new TextEncoder();
   const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(key));
   const keyHash = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
 
   const row = await db
-    .prepare('SELECT user_id FROM api_keys WHERE key_hash = ?')
+    .prepare('SELECT user_id, name FROM api_keys WHERE key_hash = ?')
     .bind(keyHash)
-    .first<{ user_id: string }>();
+    .first<{ user_id: string; name: string }>();
 
-  return row?.user_id ?? null;
+  return row ?? null;
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -107,3 +107,17 @@ CREATE TABLE IF NOT EXISTS api_keys (
 );
 CREATE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys(user_id);
 
+-- Audit log for database-altering events
+CREATE TABLE IF NOT EXISTS audit_log (
+  id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL,
+  user_id TEXT,
+  auth_method TEXT NOT NULL,
+  api_key_name TEXT,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT,
+  route TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_user_id_created_at ON audit_log(user_id, created_at DESC);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import workoutsApi from './api/workouts';
 import exercisesApi from './api/exercises';
 import * as queries from './db/queries';
 import { authMiddleware } from './middleware/auth';
+import { logAudit } from './db/audit';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -28,6 +29,7 @@ app.route('/api/exercises', exercisesApi);
 app.post('/api/data/clear', authMiddleware, async (c) => {
   const userId = c.get('userId');
   await queries.clearAllData(c.env.DB, userId);
+  await logAudit(c, { action: 'delete', entity_type: 'user', entity_id: userId });
   return c.json({ success: true });
 });
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,10 +3,14 @@ import { verifyToken } from '../auth';
 import { getUserByApiKey } from '../db/queries';
 import type { Env } from '../types';
 
-// Extend Hono's context to include userId
+export type AuthMethod = 'jwt' | 'api_key' | 'unauthenticated';
+
+// Extend Hono's context
 declare module 'hono' {
   interface ContextVariableMap {
     userId: string;
+    authMethod: AuthMethod;
+    apiKeyName: string | null;
   }
 }
 
@@ -21,11 +25,13 @@ export async function authMiddleware(c: Context<{ Bindings: Env }>, next: Next) 
 
   // Check if this is an API key (starts with wt_)
   if (token.startsWith('wt_')) {
-    const userId = await getUserByApiKey(c.env.DB, token);
-    if (!userId) {
+    const result = await getUserByApiKey(c.env.DB, token);
+    if (!result) {
       return c.json({ error: 'Invalid API key' }, 401);
     }
-    c.set('userId', userId);
+    c.set('userId', result.user_id);
+    c.set('authMethod', 'api_key');
+    c.set('apiKeyName', result.name);
     await next();
     return;
   }
@@ -38,5 +44,7 @@ export async function authMiddleware(c: Context<{ Bindings: Env }>, next: Next) 
   }
 
   c.set('userId', payload.userId);
+  c.set('authMethod', 'jwt');
+  c.set('apiKeyName', null);
   await next();
 }


### PR DESCRIPTION
Users couldn't trace which DB mutations came from their MCP trainer agent versus their own browser session, making it impossible to debug unexpected data changes.

This adds `src/db/audit.ts` plus an extension to `src/middleware/auth.ts` that attaches the auth source (JWT vs API key + key name) to the request context, and a single `logAudit` call in each mutation handler to record who did what.