### PR TITLE
fix: prevent UI clobbering server state via 3-way merge (#102)

### DIFF
--- a/e2e/sync-race.spec.ts
+++ b/e2e/sync-race.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTestUserWithExercises,
+  createWorkoutViaApi,
+  authenticatePage,
+  TestSetup,
+} from './helpers';
+
+// Regression test for issue #102: concurrent writes from another client
+// (or MCP/API) can resurrect a deleted exercise or clobber freshly-toggled
+// completed sets when the browser autosaves after a background sync poll.
+//
+// The fix introduces a 3-way merge using a captured `baseServerWorkout`
+// baseline. These e2e checks assert the merged state after the two
+// "write paths" collide:
+//   (1) a direct API PUT simulating another client modifying the workout
+//   (2) the browser's autosave writing local edits back
+test.describe('Sync Race Regression (issue #102)', () => {
+  let setup: TestSetup;
+
+  test.beforeEach(async ({ page, request }) => {
+    setup = await setupTestUserWithExercises(request);
+    await authenticatePage(page, setup.token);
+    await expect(page.locator('#main-app')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('ghost exercise does not reappear after concurrent API write + local autosave', async ({ page, request }) => {
+    // 1. Seed a workout via API with two exercises, one completed set on Bench.
+    const startTime = Date.now() - 60_000;
+    const endTime = Date.now();
+    const created = await createWorkoutViaApi(request, setup.token, {
+      start_time: startTime,
+      end_time: endTime,
+      exercises: [
+        {
+          name: 'Bench Press',
+          sets: [{ weight: 135, reps: 10, completed: true }],
+        },
+        {
+          name: 'Squat',
+          sets: [{ weight: 185, reps: 5, completed: true }],
+        },
+      ],
+    });
+    const workoutId: string = created.id;
+    expect(workoutId).toBeTruthy();
+
+    // 2. Reload so the frontend picks up history, then open the workout for editing.
+    await page.reload();
+    await expect(page.locator('#main-app')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'History', exact: true }).click();
+    await expect(page.locator('.ring-2.ring-white')).toBeVisible({ timeout: 5000 });
+    await page.locator('.ring-2.ring-white').click();
+    await expect(page.locator('#tab-workout.tab-content.active')).toBeVisible();
+    await expect(page.locator('#exercise-list').getByText('Bench Press')).toBeVisible();
+    await expect(page.locator('#exercise-list').getByText('Squat')).toBeVisible();
+
+    // 3. Delete Squat locally (user-initiated) so Bench is the only local exercise.
+    // This matches the resurrection scenario: locally-deleted exercise, still on server.
+    await page.evaluate(() => (window as any).app.removeExercise(1));
+    await expect(page.locator('#exercise-list').getByText('Squat')).toHaveCount(0);
+
+    // 4. Before the local autosave fires (1.5s debounce), another client PUTs
+    //    an update to the workout — adding a remote-only Lat Pulldown entry and
+    //    bumping updated_at. This is the server-side concurrent write.
+    const fresh = await request.get(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+    });
+    const remoteCopy = await fresh.json();
+    const concurrentPut = await request.put(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+      data: {
+        start_time: remoteCopy.start_time,
+        end_time: remoteCopy.end_time,
+        target_categories: remoteCopy.target_categories ?? null,
+        updated_at: remoteCopy.updated_at,
+        exercises: [
+          { name: 'Bench Press', sets: [{ weight: 135, reps: 10, completed: true }] },
+          { name: 'Squat',       sets: [{ weight: 185, reps: 5, completed: true }] },
+          { name: 'Lat Pulldown', sets: [{ weight: 100, reps: 12, completed: true }] },
+        ],
+      },
+    });
+    expect(concurrentPut.status()).toBe(200);
+
+    // 5. Make a local edit to trigger autosave (add a new set to Bench).
+    // The autosave will 409 because updated_at is stale, enter the
+    // mergeServerWorkout path with localAuthoritative=true, and must:
+    //  - NOT resurrect the locally-deleted Squat
+    //  - Keep the remotely-added Lat Pulldown (server addition not in base)
+    //  - Preserve the existing completed Bench set
+    await page.evaluate(() => (window as any).app.addSet(0));
+    // Event-driven wait: poll the server until the merged shape settles —
+    // Squat removed (local deletion honored), Lat Pulldown present (remote
+    // addition preserved). This covers the 1.5s autosave debounce plus the
+    // 409-conflict retry path without a fixed sleep.
+    await expect
+      .poll(
+        async () => {
+          const r = await request.get(`/api/workouts/${workoutId}`, {
+            headers: { Authorization: `Bearer ${setup.token}` },
+          });
+          const w = await r.json();
+          const names = (w.exercises as Array<{ name: string }>).map((e) => e.name);
+          return {
+            hasSquat: names.includes('Squat'),
+            hasLatPulldown: names.includes('Lat Pulldown'),
+          };
+        },
+        { timeout: 10_000, intervals: [250, 500, 1000] },
+      )
+      .toEqual({ hasSquat: false, hasLatPulldown: true });
+
+    // 6. Re-render shouldn't have brought Squat back (RESURRECTION regression).
+    await expect(page.locator('#exercise-list').getByText('Squat')).toHaveCount(0);
+
+    // 7. Lat Pulldown (remote addition, not in our base) should be present.
+    await expect(page.locator('#exercise-list').getByText('Lat Pulldown')).toBeVisible();
+
+    // 8. Bench Press should still be there with its original completed set.
+    await expect(page.locator('#exercise-list').getByText('Bench Press')).toBeVisible();
+
+    // 9. Verify server state matches the merged result (source of truth).
+    const afterResp = await request.get(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+    });
+    const afterState = await afterResp.json();
+    const names = afterState.exercises.map((e: { name: string }) => e.name).sort();
+    expect(names).not.toContain('Squat');
+    expect(names).toContain('Bench Press');
+    expect(names).toContain('Lat Pulldown');
+
+    // 10. The pre-existing completed Bench set must survive the merge.
+    const bench = afterState.exercises.find((e: { name: string }) => e.name === 'Bench Press');
+    expect(bench).toBeDefined();
+    const firstBenchSet = bench.sets.find(
+      (s: { weight: number; reps: number; completed?: boolean }) =>
+        s.weight === 135 && s.reps === 10,
+    );
+    expect(firstBenchSet).toBeDefined();
+    expect(firstBenchSet.completed).toBe(true);
+  });
+
+  test('local completed-set toggle survives a concurrent server change on a different exercise', async ({ page, request }) => {
+    // This covers the vanishing-sets regression: user toggles a set complete
+    // at roughly the same time as another client writes to the same workout
+    // (different exercise). The local toggle must not be lost.
+    const startTime = Date.now() - 60_000;
+    const endTime = Date.now();
+    const created = await createWorkoutViaApi(request, setup.token, {
+      start_time: startTime,
+      end_time: endTime,
+      exercises: [
+        { name: 'Bench Press', sets: [{ weight: 135, reps: 10, completed: false }] },
+        { name: 'Squat',       sets: [{ weight: 185, reps: 5, completed: false }] },
+      ],
+    });
+    const workoutId: string = created.id;
+
+    await page.reload();
+    await expect(page.locator('#main-app')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'History', exact: true }).click();
+    await expect(page.locator('.ring-2.ring-white')).toBeVisible({ timeout: 5000 });
+    await page.locator('.ring-2.ring-white').click();
+    await expect(page.locator('#exercise-list').getByText('Bench Press')).toBeVisible();
+
+    // Toggle Bench set to completed locally.
+    await page.evaluate(() => (window as any).app.toggleSetCompleted(0, 0));
+
+    // Concurrent server-side change: mark Squat's set completed via API.
+    const fresh = await request.get(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+    });
+    const remoteCopy = await fresh.json();
+    const concurrentPut = await request.put(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+      data: {
+        start_time: remoteCopy.start_time,
+        end_time: remoteCopy.end_time,
+        target_categories: remoteCopy.target_categories ?? null,
+        updated_at: remoteCopy.updated_at,
+        exercises: [
+          { name: 'Bench Press', sets: [{ weight: 135, reps: 10, completed: false }] },
+          { name: 'Squat',       sets: [{ weight: 185, reps: 5, completed: true }] },
+        ],
+      },
+    });
+    expect(concurrentPut.status()).toBe(200);
+
+    // Poll the server until the merged shape settles: Bench's local toggle
+    // should land AND Squat's remote toggle should be preserved. This covers
+    // the 1.5s autosave debounce and 409-retry path without a fixed sleep.
+    await expect
+      .poll(
+        async () => {
+          const r = await request.get(`/api/workouts/${workoutId}`, {
+            headers: { Authorization: `Bearer ${setup.token}` },
+          });
+          const w = await r.json();
+          const bench = w.exercises.find((e: { name: string }) => e.name === 'Bench Press');
+          const squat = w.exercises.find((e: { name: string }) => e.name === 'Squat');
+          return {
+            benchCompleted: bench?.sets[0]?.completed === true,
+            squatCompleted: squat?.sets[0]?.completed === true,
+          };
+        },
+        { timeout: 10_000, intervals: [250, 500, 1000] },
+      )
+      .toEqual({ benchCompleted: true, squatCompleted: true });
+
+    // Final assertion on the server for a clear failure message.
+    const afterResp = await request.get(`/api/workouts/${workoutId}`, {
+      headers: { Authorization: `Bearer ${setup.token}` },
+    });
+    const afterState = await afterResp.json();
+    const bench = afterState.exercises.find((e: { name: string }) => e.name === 'Bench Press');
+    const squat = afterState.exercises.find((e: { name: string }) => e.name === 'Squat');
+    expect(bench.sets[0].completed).toBe(true); // local toggle survived
+    expect(squat.sets[0].completed).toBe(true); // remote change preserved
+  });
+});

--- a/e2e/sync-race.spec.ts
+++ b/e2e/sync-race.spec.ts
@@ -21,6 +21,8 @@ test.describe('Sync Race Regression (issue #102)', () => {
   test.beforeEach(async ({ page, request }) => {
     setup = await setupTestUserWithExercises(request);
     await authenticatePage(page, setup.token);
+    // removeExercise() calls window.confirm(); auto-accept so the delete lands.
+    page.on('dialog', (dialog) => void dialog.accept());
     await expect(page.locator('#main-app')).toBeVisible({ timeout: 10000 });
   });
 
@@ -89,7 +91,13 @@ test.describe('Sync Race Regression (issue #102)', () => {
     //  - NOT resurrect the locally-deleted Squat
     //  - Keep the remotely-added Lat Pulldown (server addition not in base)
     //  - Preserve the existing completed Bench set
-    await page.evaluate(() => (window as any).app.addSet(0));
+    await page.evaluate(() => {
+      const app = (window as any).app;
+      // showAddSetForm populates #weight-0/#reps-0 with last-set defaults;
+      // saveSetInline reads them and calls scheduleAutoSave().
+      app.showAddSetForm(0);
+      app.saveSetInline(0);
+    });
     // Event-driven wait: poll the server until the merged shape settles —
     // Squat removed (local deletion honored), Lat Pulldown present (remote
     // addition preserved). This covers the 1.5s autosave debounce plus the

--- a/src/frontend/merge.test.ts
+++ b/src/frontend/merge.test.ts
@@ -1,0 +1,299 @@
+// Regression tests for 3-way merge in src/frontend/merge.ts, covering the
+// "exercise resurrection / completed-sets vanishing" bug (issue #102).
+import { describe, it, expect } from 'vitest';
+import { mergeWorkouts, type LocalWorkoutView } from './merge';
+import type { Workout, WorkoutExercise, Set as WorkoutSet } from './api';
+
+function ex(name: string, sets: WorkoutSet[] = [], extras: Partial<WorkoutExercise> = {}): WorkoutExercise {
+  return { name, sets, ...extras };
+}
+
+function baseWorkout(id: string, exercises: WorkoutExercise[]): Workout {
+  return {
+    id,
+    user_id: 'u1',
+    start_time: 1_700_000_000_000,
+    exercises,
+    created_at: 1_700_000_000_000,
+    updated_at: 1_700_000_000_000,
+  };
+}
+
+function serverWorkout(id: string, exercises: WorkoutExercise[], updatedAt = 1_700_000_500_000): Workout {
+  return {
+    id,
+    user_id: 'u1',
+    start_time: 1_700_000_000_000,
+    exercises,
+    created_at: 1_700_000_000_000,
+    updated_at: updatedAt,
+  };
+}
+
+function localView(exercises: WorkoutExercise[], targetCategories?: LocalWorkoutView['targetCategories']): LocalWorkoutView {
+  return { exercises, targetCategories };
+}
+
+describe('mergeWorkouts — 3-way merge', () => {
+  describe('exercise-level triage (issue #102 regressions)', () => {
+    it('preserves local deletion when server has not changed that exercise (no resurrection)', () => {
+      // Base: [Bench, Squat]. User deletes Squat locally. Server still has both.
+      const base = baseWorkout('w1', [ex('Bench'), ex('Squat')]);
+      const local = localView([ex('Bench')]);
+      const server = serverWorkout('w1', [ex('Bench'), ex('Squat')]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      const names = result.exercises.map(e => e.name);
+      expect(names).toEqual(['Bench']);
+      expect(names).not.toContain('Squat');
+    });
+
+    it('drops an exercise that was deleted on the server (remote deletion)', () => {
+      // Base: [Bench, Squat]. Server deleted Squat. Local still has both.
+      const base = baseWorkout('w1', [ex('Bench'), ex('Squat')]);
+      const local = localView([ex('Bench'), ex('Squat')]);
+      const server = serverWorkout('w1', [ex('Bench')]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises.map(e => e.name)).toEqual(['Bench']);
+    });
+
+    it('adds a remote-added exercise (not in base, not in local)', () => {
+      // Base: [Bench]. Server added Deadlift. Local unchanged.
+      const base = baseWorkout('w1', [ex('Bench')]);
+      const local = localView([ex('Bench')]);
+      const server = serverWorkout('w1', [ex('Bench'), ex('Deadlift', [{ weight: 225, reps: 5 }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises.map(e => e.name)).toEqual(['Bench', 'Deadlift']);
+      const dl = result.exercises.find(e => e.name === 'Deadlift')!;
+      expect(dl.sets).toEqual([{ weight: 225, reps: 5 }]);
+    });
+
+    it('keeps a local-added exercise (not in base, not on server)', () => {
+      // Base: [Bench]. Local added Squat. Server unchanged.
+      const base = baseWorkout('w1', [ex('Bench')]);
+      const local = localView([ex('Bench'), ex('Squat', [{ weight: 185, reps: 5 }])]);
+      const server = serverWorkout('w1', [ex('Bench')]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises.map(e => e.name)).toEqual(['Bench', 'Squat']);
+      const sq = result.exercises.find(e => e.name === 'Squat')!;
+      expect(sq.sets).toEqual([{ weight: 185, reps: 5 }]);
+    });
+
+    it('preserves concurrent additions on both sides (different exercises)', () => {
+      // Base: [Bench]. Local added Squat. Server added Deadlift.
+      const base = baseWorkout('w1', [ex('Bench')]);
+      const local = localView([ex('Bench'), ex('Squat')]);
+      const server = serverWorkout('w1', [ex('Bench'), ex('Deadlift')]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      const names = result.exercises.map(e => e.name).sort();
+      expect(names).toEqual(['Bench', 'Deadlift', 'Squat']);
+    });
+  });
+
+  describe('set-level merge (vanishing-sets regression)', () => {
+    it('preserves local completed:true when server has no change on that exercise', () => {
+      // Base: one set uncompleted. Local toggled completed=true. Server unchanged.
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 135, reps: 10, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      const mergedSet = result.exercises[0].sets[0];
+      expect(mergedSet.completed).toBe(true);
+      expect(mergedSet.weight).toBe(135);
+      expect(mergedSet.reps).toBe(10);
+    });
+
+    it('applies a remote set change when local is unchanged', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 135, reps: 10, completed: false }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 135, reps: 12, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: false });
+
+      expect(result.exercises[0].sets[0].reps).toBe(12);
+    });
+
+    it('true conflict with localAuthoritative: local wins, hadConflict is true', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 140, reps: 10, completed: false }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 150, reps: 10, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises[0].sets[0].weight).toBe(140);
+      expect(result.hadConflict).toBe(true);
+    });
+
+    it('true conflict with localAuthoritative=false: server wins', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 140, reps: 10, completed: false }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 150, reps: 10, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: false });
+
+      expect(result.exercises[0].sets[0].weight).toBe(150);
+      expect(result.hadConflict).toBe(true);
+    });
+
+    it('preserves a local-added set (local has more sets than base/server)', () => {
+      // Base and server have one set; local added a second.
+      const base = baseWorkout('w1', [ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+      const local = localView([
+        ex('Bench', [
+          { weight: 135, reps: 10, completed: true },
+          { weight: 145, reps: 8, completed: false },
+        ]),
+      ]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises[0].sets).toHaveLength(2);
+      expect(result.exercises[0].sets[1]).toMatchObject({ weight: 145, reps: 8 });
+    });
+  });
+
+  describe('known limitations — documented, not fixed here', () => {
+    // TODO: set identity by index; revisit with stable set ids.
+    // Sets are identified positionally (by array index) within an exercise.
+    // When local deletes a set, the indexes of subsequent sets shift, so a
+    // concurrent server edit to a later set (e.g. a `note` change on set C)
+    // is aligned against the wrong local slot and silently dropped. A proper
+    // fix requires stable per-set ids in the schema — deferred to a follow-up.
+    it('DOCUMENTS: server edit to a later set is lost when local deletes an earlier set (index-based identity)', () => {
+      // Base: [A, B, C]. Local deletes B -> [A, C]. Server edits C's note -> [A, B, C'].
+      const base = baseWorkout('w1', [
+        ex('Bench', [
+          { weight: 100, reps: 5 },
+          { weight: 110, reps: 5 },
+          { weight: 120, reps: 5, note: 'original' },
+        ]),
+      ]);
+      const local = localView([
+        ex('Bench', [
+          { weight: 100, reps: 5 },
+          { weight: 120, reps: 5, note: 'original' },
+        ]),
+      ]);
+      const server = serverWorkout('w1', [
+        ex('Bench', [
+          { weight: 100, reps: 5 },
+          { weight: 110, reps: 5 },
+          { weight: 120, reps: 5, note: 'server edit' },
+        ]),
+      ]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      // CURRENT behavior: local deletion of B wins, and because set identity
+      // is positional the server's note change on C never lands on the
+      // surviving slot. The 'server edit' note is silently dropped.
+      const sets = result.exercises[0].sets;
+      expect(sets).toHaveLength(2);
+      expect(sets[0]).toMatchObject({ weight: 100, reps: 5 });
+      expect(sets[1]).toMatchObject({ weight: 120, reps: 5 });
+      // This is the known-limitation assertion — not desired behavior, just
+      // locked-in so any future change to set identity semantics will
+      // surface here and force a conscious revisit.
+      expect(sets[1].note).toBe('original');
+      expect(sets[1].note).not.toBe('server edit');
+    });
+  });
+
+  describe('baseline behavior', () => {
+    it('with null base (no common ancestor), falls back gracefully without crashing', () => {
+      const local = localView([ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 135, reps: 10, completed: false }])]);
+
+      expect(() => mergeWorkouts(null, local, server, { localAuthoritative: true })).not.toThrow();
+
+      const result = mergeWorkouts(null, local, server, { localAuthoritative: true });
+      // Legacy behavior: server exercise is taken as base, local notes preserved.
+      // The exact set-level semantics of the null-base path aren't under test here —
+      // this assertion just confirms non-crash behavior returns a plausible result.
+      expect(result.exercises).toHaveLength(1);
+      expect(result.exercises[0].name).toBe('Bench');
+    });
+  });
+
+  describe('isPR field stripping', () => {
+    it('does not leak server-side isPR through a merged set', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      // Server has isPR=true; we don't want to trust it — PR flags are recomputed client-side.
+      const serverSet: WorkoutSet = { weight: 135, reps: 10, completed: false, isPR: true };
+      const local = localView([ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+      const server = serverWorkout('w1', [ex('Bench', [serverSet])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises[0].sets[0].isPR).toBeUndefined();
+    });
+
+    it('does not leak isPR when the set is a remote append', () => {
+      const base = baseWorkout('w1', [ex('Bench', [])]);
+      const local = localView([ex('Bench', [])]);
+      const server = serverWorkout('w1', [
+        ex('Bench', [{ weight: 200, reps: 5, completed: true, isPR: true }]),
+      ]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises[0].sets).toHaveLength(1);
+      expect(result.exercises[0].sets[0].isPR).toBeUndefined();
+      expect(result.exercises[0].sets[0].weight).toBe(200);
+    });
+
+    it('does not leak isPR on a local-appended set', () => {
+      const base = baseWorkout('w1', [ex('Bench', [])]);
+      // Local added a set the client mis-flagged with isPR=true; we still strip it.
+      const local = localView([ex('Bench', [{ weight: 225, reps: 5, completed: true, isPR: true }])]);
+      const server = serverWorkout('w1', [ex('Bench', [])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.exercises[0].sets).toHaveLength(1);
+      expect(result.exercises[0].sets[0].isPR).toBeUndefined();
+    });
+  });
+
+  describe('hadConflict reporting', () => {
+    it('does not report conflict when only one side changed a set field', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 135, reps: 10, completed: true }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 135, reps: 10, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.hadConflict).toBe(false);
+    });
+
+    it('does not report conflict when both sides wrote the same value', () => {
+      const baseSet: WorkoutSet = { weight: 135, reps: 10, completed: false };
+      const base = baseWorkout('w1', [ex('Bench', [baseSet])]);
+      const local = localView([ex('Bench', [{ weight: 140, reps: 10, completed: false }])]);
+      const server = serverWorkout('w1', [ex('Bench', [{ weight: 140, reps: 10, completed: false }])]);
+
+      const result = mergeWorkouts(base, local, server, { localAuthoritative: true });
+
+      expect(result.hadConflict).toBe(false);
+      expect(result.exercises[0].sets[0].weight).toBe(140);
+    });
+  });
+});

--- a/src/frontend/merge.ts
+++ b/src/frontend/merge.ts
@@ -1,0 +1,251 @@
+// Pure 3-way merge logic for the active-edit workout sync.
+// Extracted from workout.ts so it can be unit-tested without the DOM.
+//
+// See src/frontend/workout.ts::mergeServerWorkout for the stateful caller that
+// applies these results to `state.currentWorkout` and re-renders.
+import type { Workout, Set as WorkoutSet, WorkoutExercise, MuscleGroup } from './api';
+
+export interface MergeOpts {
+  localAuthoritative: boolean;
+}
+
+// A "local" workout view mirrors the shape held in state.currentWorkout:
+// no id (when brand new), targetCategories instead of target_categories, etc.
+// We accept both shapes here by requiring only the fields we read.
+export interface LocalWorkoutView {
+  exercises: WorkoutExercise[];
+  targetCategories?: MuscleGroup[];
+}
+
+export interface MergeResult {
+  exercises: WorkoutExercise[];
+  targetCategories: MuscleGroup[] | undefined;
+  hadConflict: boolean;
+}
+
+// Sets lack stable ids, so match by position within an exercise.
+// When lengths differ, indices beyond the shortest list are treated as
+// one-sided additions (local append or server append).
+export function mergeSets(
+  baseSets: WorkoutSet[] | null,
+  localSets: WorkoutSet[],
+  serverSets: WorkoutSet[],
+  opts: MergeOpts
+): { sets: WorkoutSet[]; hadConflict: boolean } {
+  const maxLen = Math.max(localSets.length, serverSets.length);
+  const merged: WorkoutSet[] = [];
+  let hadConflict = false;
+
+  for (let i = 0; i < maxLen; i++) {
+    const baseSet = baseSets && i < baseSets.length ? baseSets[i] : null;
+    const localSet = i < localSets.length ? localSets[i] : null;
+    const serverSet = i < serverSets.length ? serverSets[i] : null;
+
+    if (localSet && !serverSet) {
+      if (baseSet) {
+        // In base, still local, gone from server -> remote deletion. Drop.
+        continue;
+      }
+      // Local append (not in base) -> keep local addition.
+      const out = structuredClone(localSet);
+      delete out.isPR;
+      merged.push(out);
+      continue;
+    }
+    if (!localSet && serverSet) {
+      if (baseSet) {
+        // In base, still on server, gone locally -> local deletion. Drop.
+        continue;
+      }
+      // Remote append -> keep server addition.
+      const out = structuredClone(serverSet);
+      delete out.isPR;
+      merged.push(out);
+      continue;
+    }
+    if (!localSet && !serverSet) {
+      continue;
+    }
+
+    // Both sides have the set at this index: do per-field 3-way merge.
+    const out: WorkoutSet = structuredClone(localSet!);
+    const s = serverSet!;
+    const b = baseSet;
+
+    const mergeField = <K extends keyof WorkoutSet>(key: K): void => {
+      const lv = localSet![key];
+      const sv = s[key];
+      const bv = b ? b[key] : undefined;
+      const localChanged = b ? lv !== bv : lv !== undefined;
+      const serverChanged = b ? sv !== bv : sv !== undefined;
+
+      if (localChanged && !serverChanged) {
+        out[key] = lv;
+      } else if (!localChanged && serverChanged) {
+        out[key] = sv;
+      } else if (localChanged && serverChanged) {
+        if (lv !== sv) hadConflict = true;
+        out[key] = opts.localAuthoritative ? lv : sv;
+      } else {
+        out[key] = lv;
+      }
+    };
+
+    mergeField('weight');
+    mergeField('reps');
+    mergeField('completed');
+    mergeField('missed');
+    mergeField('note');
+    delete out.isPR;
+
+    merged.push(out);
+  }
+
+  return { sets: merged, hadConflict };
+}
+
+// Core merge. Returns a plain result object; the caller is responsible for
+// mutating state.currentWorkout, refreshing baseServerWorkout, showing toasts,
+// and re-rendering.
+export function mergeWorkouts(
+  base: Workout | null,
+  local: LocalWorkoutView,
+  server: Workout,
+  opts: MergeOpts
+): MergeResult {
+  const localExercises = local.exercises;
+  const serverExercises = server.exercises;
+  const baseExercises = base ? base.exercises : null;
+
+  let hadConflict = false;
+  const merged: WorkoutExercise[] = [];
+
+  if (!base) {
+    // Legacy two-way behavior (no common ancestor).
+    if (opts.localAuthoritative) {
+      if (localExercises.length === 0 && serverExercises.length > 0) {
+        for (const serverEx of serverExercises) {
+          merged.push(structuredClone(serverEx));
+        }
+      } else {
+        for (const localEx of localExercises) {
+          const serverEx = serverExercises.find(se => se.name === localEx.name);
+          if (serverEx) {
+            const mergedEx = structuredClone(serverEx);
+            if (localEx.notes && !serverEx.notes) {
+              mergedEx.notes = localEx.notes;
+            }
+            merged.push(mergedEx);
+          } else {
+            merged.push(structuredClone(localEx));
+          }
+        }
+      }
+    } else {
+      for (const serverEx of serverExercises) {
+        const localEx = localExercises.find(le => le.name === serverEx.name);
+        const mergedEx = structuredClone(serverEx);
+        if (localEx?.notes && !serverEx.notes) {
+          mergedEx.notes = localEx.notes;
+        }
+        merged.push(mergedEx);
+      }
+      for (const localEx of localExercises) {
+        const serverEx = serverExercises.find(se => se.name === localEx.name);
+        if (!serverEx) {
+          merged.push(structuredClone(localEx));
+        }
+      }
+    }
+  } else {
+    // 3-way merge at the exercise level. Identify exercises by name.
+    const seenNames = new Set<string>();
+
+    for (const localEx of localExercises) {
+      if (seenNames.has(localEx.name)) continue;
+      seenNames.add(localEx.name);
+
+      const inBase = baseExercises!.some(be => be.name === localEx.name);
+      const serverEx = serverExercises.find(se => se.name === localEx.name);
+
+      if (!serverEx && inBase) {
+        // Remote deletion. Drop.
+        continue;
+      }
+      if (!serverEx && !inBase) {
+        // Local addition -> keep.
+        merged.push(structuredClone(localEx));
+        continue;
+      }
+      // Exists on both sides -> descend into set-level merge.
+      const baseEx = baseExercises!.find(be => be.name === localEx.name) || null;
+      const { sets, hadConflict: setConflict } = mergeSets(
+        baseEx ? baseEx.sets : null,
+        localEx.sets,
+        serverEx!.sets,
+        opts
+      );
+      if (setConflict) hadConflict = true;
+
+      const mergedEx = structuredClone(serverEx!);
+      mergedEx.sets = sets;
+
+      const mergeExerciseField = <K extends keyof typeof localEx>(key: K): void => {
+        const lv = localEx[key];
+        const sv = serverEx![key];
+        const bv = baseEx ? baseEx[key] : undefined;
+        const localChanged = baseEx ? lv !== bv : lv !== undefined;
+        const serverChanged = baseEx ? sv !== bv : sv !== undefined;
+        if (localChanged && !serverChanged) {
+          (mergedEx as typeof localEx)[key] = lv;
+        } else if (!localChanged && serverChanged) {
+          (mergedEx as typeof localEx)[key] = sv;
+        } else if (localChanged && serverChanged) {
+          if (lv !== sv) hadConflict = true;
+          (mergedEx as typeof localEx)[key] = opts.localAuthoritative ? lv : sv;
+        } else {
+          (mergedEx as typeof localEx)[key] = lv;
+        }
+      };
+      mergeExerciseField('completed');
+      mergeExerciseField('notes');
+
+      merged.push(mergedEx);
+    }
+
+    // Server-only additions: in server, not in local, not in base -> keep.
+    for (const serverEx of serverExercises) {
+      if (seenNames.has(serverEx.name)) continue;
+      const inBase = baseExercises!.some(be => be.name === serverEx.name);
+      if (inBase) {
+        // In base, gone locally -> local deletion. Drop.
+        continue;
+      }
+      merged.push(structuredClone(serverEx));
+    }
+  }
+
+  // Merge target_categories / targetCategories
+  let targetCategories: MuscleGroup[] | undefined;
+  if (base) {
+    const localCats = JSON.stringify(local.targetCategories ?? null);
+    const serverCats = JSON.stringify(server.target_categories ?? null);
+    const baseCats = JSON.stringify(base.target_categories ?? null);
+    const localChanged = localCats !== baseCats;
+    const serverChanged = serverCats !== baseCats;
+    if (localChanged && !serverChanged) {
+      targetCategories = local.targetCategories;
+    } else if (!localChanged && serverChanged) {
+      targetCategories = server.target_categories;
+    } else if (localChanged && serverChanged) {
+      if (localCats !== serverCats) hadConflict = true;
+      targetCategories = opts.localAuthoritative ? local.targetCategories : server.target_categories;
+    } else {
+      targetCategories = server.target_categories;
+    }
+  } else {
+    targetCategories = server.target_categories;
+  }
+
+  return { exercises: merged, targetCategories, hadConflict };
+}

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -15,11 +15,17 @@ import {
   buildWorkoutDelete,
   newClientId,
 } from './offline/mutations';
+import { mergeWorkouts } from './merge';
 
 // ==================== WORKOUT STATE ====================
 let isEditingFromHistory = false;
 let autoSaveTimeout: ReturnType<typeof setTimeout> | null = null;
 let editingWorkoutUpdatedAt: number | null = null;
+// The "common ancestor" for 3-way merge: the last-known-server snapshot
+// of the workout we're currently editing. Used by mergeServerWorkout to
+// distinguish "local deletion" from "remote addition" (and vice versa).
+// Deep-cloned whenever we take a fresh authoritative server view.
+let baseServerWorkout: Workout | null = null;
 let autoSaveConflictRetries = 0;
 const MAX_AUTO_SAVE_CONFLICT_RETRIES = 3;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -124,6 +130,7 @@ function startWorkoutInternal(targetCategories?: MuscleGroup[]): void {
   };
   state.editingWorkoutId = null;
   editingWorkoutUpdatedAt = null;
+  baseServerWorkout = null;
   autoSaveConflictRetries = 0;
   isEditingFromHistory = false;
   expandedNotes.clear();
@@ -150,6 +157,7 @@ export function startWorkout(): void {
   };
   state.editingWorkoutId = null;
   editingWorkoutUpdatedAt = null;
+  baseServerWorkout = null;
   autoSaveConflictRetries = 0;
   isEditingFromHistory = false;
   expandedNotes.clear();
@@ -182,6 +190,7 @@ export async function confirmDeleteCurrentWorkout(): Promise<void> {
     state.currentWorkout = null;
     state.editingWorkoutId = null;
     editingWorkoutUpdatedAt = null;
+    baseServerWorkout = null;
     autoSaveConflictRetries = 0;
     isEditingFromHistory = false;
     expandedNotes.clear();
@@ -240,6 +249,7 @@ async function autoSaveWorkout(): Promise<void> {
       isNew = true;
       state.editingWorkoutId = resourceId;
       editingWorkoutUpdatedAt = null;
+      baseServerWorkout = null;
     }
 
     await enqueue(buildWorkoutUpsert(resourceId, isNew, workoutData));
@@ -258,12 +268,24 @@ async function autoSaveWorkout(): Promise<void> {
 // Updates editingWorkoutUpdatedAt so subsequent auto-saves don't send stale
 // updated_at and trigger infinite 409 loops.
 export function handleWorkoutSynced(_mutation: Mutation, response: unknown): void {
-  const res = response as { updated_at?: number } | null | undefined;
+  const res = response as (Workout & { updated_at?: number }) | null | undefined;
   if (res?.updated_at !== undefined && state.editingWorkoutId) {
     // Only update if this response is for the workout we're currently editing
-    const resAny = response as { id?: string } | null | undefined;
-    if (!resAny?.id || resAny.id === state.editingWorkoutId) {
+    if (!res.id || res.id === state.editingWorkoutId) {
       editingWorkoutUpdatedAt = res.updated_at;
+      // Refresh the 3-way merge baseline: the server has now accepted our
+      // write, so that exact shape is the new common ancestor for any
+      // future remote changes we haven't seen yet.
+      if (res.id && Array.isArray(res.exercises)) {
+        baseServerWorkout = structuredClone(res) as Workout;
+      } else {
+        // Thin response (bare ACK — has updated_at but no exercises array):
+        // we cannot trust the existing base to still be the common ancestor
+        // alongside the new updated_at. Invalidate it so the next merge
+        // takes the null-base fallback path rather than comparing against
+        // a stale snapshot and flagging everything as a conflict.
+        baseServerWorkout = null;
+      }
     }
   }
 }
@@ -280,6 +302,10 @@ export function handleWorkoutConflict(mutation: Mutation, current: unknown): voi
   renderWorkout();
 }
 
+// ==================== 3-WAY MERGE ====================
+// Pure merge logic lives in ./merge.ts so it can be unit-tested without DOM.
+// This wrapper applies the result to state, refreshes the baseline, and
+// re-renders.
 function mergeServerWorkout(
   serverWorkout: Workout,
   opts: { localAuthoritative: boolean }
@@ -288,75 +314,27 @@ function mergeServerWorkout(
 
   editingWorkoutUpdatedAt = serverWorkout.updated_at;
 
-  const localExercises = state.currentWorkout.exercises;
-  const serverExercises = serverWorkout.exercises;
+  // Base must refer to the same workout we're merging; otherwise treat as
+  // absent and fall back to the legacy two-way behavior.
+  const base =
+    baseServerWorkout && baseServerWorkout.id === serverWorkout.id
+      ? baseServerWorkout
+      : null;
 
-  // The two callers have different semantic needs:
-  //
-  // - autoSaveWorkout (409 conflict path): localAuthoritative=true.
-  //   The local exercise list reflects the user's in-progress edits,
-  //   including pending DELETIONS that haven't been flushed yet.
-  //   If we re-introduced server-only exercises here, the next
-  //   auto-save would resurrect the exercise the user just deleted.
-  //
-  // - syncPoll (background poll path): localAuthoritative=false.
-  //   Another device/session may have ADDED exercises to this workout.
-  //   We must surface those additions; dropping server-only exercises
-  //   would hide remote work and the next auto-save would erase it
-  //   from the server too.
-  const merged = [];
+  const result = mergeWorkouts(base, state.currentWorkout, serverWorkout, opts);
 
-  if (opts.localAuthoritative) {
-    // Safety: if local has no exercises but server does, don't wipe server data.
-    // An empty local list means stale state, not intentional deletion of everything.
-    if (localExercises.length === 0 && serverExercises.length > 0) {
-      for (const serverEx of serverExercises) {
-        merged.push(JSON.parse(JSON.stringify(serverEx)));
-      }
-    } else {
-      // Local-biased: iterate local exercises, enrich from server matches,
-      // drop server-only exercises (they were deleted locally).
-      for (const localEx of localExercises) {
-        const serverEx = serverExercises.find(se => se.name === localEx.name);
-        if (serverEx) {
-          // Exercise exists in both: start with server data, overlay local edits
-          const mergedEx = JSON.parse(JSON.stringify(serverEx));
-          // Keep local notes if server has none
-          if (localEx.notes && !serverEx.notes) {
-            mergedEx.notes = localEx.notes;
-          }
-          merged.push(mergedEx);
-        } else {
-          // Exercise only exists locally (user added it) — keep as-is
-          merged.push(JSON.parse(JSON.stringify(localEx)));
-        }
-      }
-    }
-  } else {
-    // Server-biased: start with server exercises (preserves server ordering
-    // and any remote additions), then append local-only exercises the user
-    // has added but not yet synced.
-    for (const serverEx of serverExercises) {
-      const localEx = localExercises.find(le => le.name === serverEx.name);
-      const mergedEx = JSON.parse(JSON.stringify(serverEx));
-      // Keep local notes if server has none
-      if (localEx?.notes && !serverEx.notes) {
-        mergedEx.notes = localEx.notes;
-      }
-      merged.push(mergedEx);
-    }
-    for (const localEx of localExercises) {
-      const serverEx = serverExercises.find(se => se.name === localEx.name);
-      if (!serverEx) {
-        merged.push(JSON.parse(JSON.stringify(localEx)));
-      }
-    }
+  state.currentWorkout.exercises = result.exercises;
+  state.currentWorkout.targetCategories = result.targetCategories;
+
+  // Update the baseline to the just-merged server view. This becomes the
+  // common ancestor for the next merge round.
+  baseServerWorkout = structuredClone(serverWorkout);
+
+  if (result.hadConflict && opts.localAuthoritative) {
+    // In the autosave (localAuthoritative) path local wins on true
+    // conflicts; show a toast so the user knows their changes were kept.
+    showToast('Merged conflicting edits — your changes kept');
   }
-
-  state.currentWorkout.exercises = merged;
-
-  // Always take server's target categories (including when cleared)
-  state.currentWorkout.targetCategories = serverWorkout.target_categories;
 
   renderWorkout();
 }
@@ -693,6 +671,9 @@ export async function refreshCurrentWorkout(): Promise<boolean> {
       exercises: JSON.parse(JSON.stringify(workout.exercises)),
     };
     editingWorkoutUpdatedAt = workout.updated_at;
+    // Fresh authoritative server view: reset the 3-way merge baseline so
+    // subsequent server polls/conflicts have a correct common ancestor.
+    baseServerWorkout = structuredClone(workout);
     renderWorkout();
     return true;
   } catch (error) {
@@ -701,6 +682,7 @@ export async function refreshCurrentWorkout(): Promise<boolean> {
       state.currentWorkout = null;
       state.editingWorkoutId = null;
       editingWorkoutUpdatedAt = null;
+      baseServerWorkout = null;
       autoSaveConflictRetries = 0;
       isEditingFromHistory = false;
       expandedNotes.clear();
@@ -724,6 +706,10 @@ export function editWorkout(id: string): void {
   };
   state.editingWorkoutId = id;
   editingWorkoutUpdatedAt = source.updated_at;
+  // Capture the initial server view as the 3-way merge baseline. Any
+  // subsequent server poll/conflict compares local edits against this
+  // snapshot to detect one-sided changes unambiguously.
+  baseServerWorkout = structuredClone(source);
   isEditingFromHistory = true;
   expandedNotes.clear();
   updateWorkoutTitle();
@@ -793,6 +779,7 @@ async function syncPoll(): Promise<void> {
       state.currentWorkout = null;
       state.editingWorkoutId = null;
       editingWorkoutUpdatedAt = null;
+      baseServerWorkout = null;
       autoSaveConflictRetries = 0;
       isEditingFromHistory = false;
       expandedNotes.clear();
@@ -878,5 +865,6 @@ export function addExerciseSetting(exerciseId: string): void {
 // ==================== RESET HELPERS ====================
 export function resetWorkoutState(): void {
   editingWorkoutUpdatedAt = null;
+  baseServerWorkout = null;
   autoSaveConflictRetries = 0;
 }

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -299,6 +299,15 @@ export function handleWorkoutConflict(mutation: Mutation, current: unknown): voi
   // Only handle conflicts for the workout we're currently editing
   if (mutation.resourceId !== state.editingWorkoutId) return;
   mergeServerWorkout(serverWorkout, { localAuthoritative: true });
+  // Write the merged state back into the mutation body. Without this, the
+  // 409-replay in sync.ts only patches `updated_at` into the original body
+  // and re-sends the pre-merge local exercises — silently clobbering any
+  // remote additions we just merged in (e.g. a concurrent Lat Pulldown add).
+  if (mutation.body && typeof mutation.body === 'object') {
+    const body = mutation.body as Record<string, unknown>;
+    body.exercises = state.currentWorkout.exercises;
+    body.target_categories = state.currentWorkout.targetCategories ?? null;
+  }
   renderWorkout();
 }
 


### PR DESCRIPTION
Fixes #102. Mid-workout the UI was clobbering server state — deleted exercises resurrected, completed sets (incl. PRs) vanished — because merge had no baseline. Now tracks `baseServerWorkout` as a common ancestor and does a real 3-way merge at exercise + per-set-field granularity. Core logic in `src/frontend/merge.ts`; baseline lifecycle in `src/frontend/workout.ts`. Index-based set identity is a known limitation (documented + TODO in tests).