### PR TITLE
Emergency: disable sync-poll merge (eating in-progress sets)

### DIFF
--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -775,22 +775,19 @@ function handleVisibilityChange(): void {
   }
 }
 
+// Sync poll disabled (emergency hot-fix): the server-biased merge was
+// racing with in-progress local edits and destroying sets/weight/reps
+// values mid-workout. The guard `autoSaveTimeout !== null` is checked at
+// entry, but any edit landing during the in-flight `getWorkout()` await
+// is then clobbered by the merge when the response returns. Until a
+// conflict-free merge is in place, never pull server state over the
+// active workout. A deleted-on-server (404) workout is still handled.
 async function syncPoll(): Promise<void> {
-  const activeEl = document.activeElement;
-  const isUserEditing = activeEl instanceof HTMLInputElement && activeEl.closest('#current-workout');
-  if (!state.editingWorkoutId || autoSaveTimeout !== null || isAutoSaving || isSyncPolling || isUserEditing) {
-    return;
-  }
-
+  if (!state.editingWorkoutId || isSyncPolling) return;
   isSyncPolling = true;
   try {
-    const workout = await api.getWorkout(state.editingWorkoutId);
-
-    if (workout.updated_at === editingWorkoutUpdatedAt) {
-      return;
-    }
-
-    mergeServerWorkout(workout, { localAuthoritative: false });
+    await api.getWorkout(state.editingWorkoutId);
+    // Intentionally do NOT merge. We only want the 404 side-effect below.
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       state.currentWorkout = null;


### PR DESCRIPTION
Already deployed to prod as version `ff608c5c-dec9-483c-9ac5-149ab799f444` — the user was actively losing sets mid-workout.

The 5s `syncPoll` GET was racing with active-workout edits: guard checks at entry, but any tap/keystroke during the in-flight `getWorkout()` await was then clobbered by `mergeServerWorkout` in server-authoritative mode (takes each server exercise wholesale, preserving only local notes). The reverted state was then re-persisted by the next auto-save, making the loss permanent.

Audit-log evidence (emily, 2026-04-23 UTC, JWT only, `PUT /api/workouts/:id`): rapid bursts like `15:02:12, :26, :32, :53, :57, 15:03:01` — 6 updates in 49s, consistent with auto-save → sync-poll merge → auto-save loops.

This PR keeps the 404 side-effect (externally-deleted workouts clean up local state) but removes the merge entirely. Multi-device real-time sync regresses; data integrity wins.

Follow-up (not in this PR): re-enable sync-poll with a merge that preserves local additions/edits and re-verifies guards after the `await`, or switches to a server-sent-events/change-token model instead of polling.