### PR TITLE
feat: edit workout date when editing from history

### DIFF
--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -18,7 +18,7 @@ import {
   toggleSetCompleted, toggleSetMissed, toggleNoteField,
   showAddSetForm, hideAddSetForm, saveSetInline, updateSet, deleteSet,
   showExerciseNotes, hideExerciseNotes, saveExerciseNotes,
-  renderWorkout, scheduleAutoSave, editWorkout, resetWorkoutState,
+  renderWorkout, scheduleAutoSave, editWorkout, editWorkoutDate, resetWorkoutState,
   refreshCurrentWorkout, startSyncPolling, stopSyncPolling,
   editExerciseSetting, addExerciseSetting,
   handleWorkoutSynced, handleWorkoutConflict,
@@ -223,6 +223,7 @@ async function init(): Promise<void> {
 // Export app object to window for onclick handlers
 (window as unknown as Record<string, unknown>).app = {
   startWorkout,
+  editWorkoutDate,
   showDeleteCurrentWorkoutConfirm,
   cancelDeleteCurrentWorkout,
   confirmDeleteCurrentWorkout,

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -174,9 +174,17 @@
 
         <div id="workout-active" class="screen">
           <header class="sticky top-0 z-10 bg-swiss-bg flex justify-between items-center px-4 pt-[calc(0.75rem+env(safe-area-inset-top))] pb-3 border-b border-swiss-border">
-            <button onclick="app.showEditCategories()" class="text-left hover:text-swiss-red transition-colors">
-              <h1 class="text-lg font-bold uppercase tracking-[0.15em]" id="workout-title">Today's Workout</h1>
-            </button>
+            <div class="flex items-center gap-2">
+              <button onclick="app.showEditCategories()" class="text-left hover:text-swiss-red transition-colors">
+                <h1 class="text-lg font-bold uppercase tracking-[0.15em]" id="workout-title">Today's Workout</h1>
+              </button>
+              <button id="edit-workout-date-btn" onclick="app.editWorkoutDate()" class="hidden text-swiss-text-secondary hover:text-swiss-red transition-colors p-1" title="Change date">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                </svg>
+              </button>
+              <input type="date" id="workout-date-input" class="sr-only" tabindex="-1" aria-hidden="true" />
+            </div>
             <div class="flex items-center gap-2">
               <span id="sync-indicator" class="sync-indicator hidden" title="Sync status"></span>
               <button onclick="app.refresh()" class="refresh-icon" title="Refresh">

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -143,11 +143,79 @@ function startWorkoutInternal(targetCategories?: MuscleGroup[]): void {
 function updateWorkoutTitle(): void {
   if (!state.currentWorkout) return;
 
+  const dateBtn = document.getElementById('edit-workout-date-btn');
   if (isEditingFromHistory) {
     $('workout-title').textContent = formatDate(state.currentWorkout.startTime);
+    dateBtn?.classList.remove('hidden');
   } else {
     $('workout-title').textContent = "Today's Workout";
+    dateBtn?.classList.add('hidden');
   }
+}
+
+// ==================== EDIT WORKOUT DATE ====================
+// Format a timestamp as YYYY-MM-DD in the user's local timezone so the
+// native date-input pre-fills correctly regardless of UTC offset.
+function formatLocalDateInput(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+let dateInputBound = false;
+
+export function editWorkoutDate(): void {
+  if (!state.currentWorkout) return;
+  const input = document.getElementById('workout-date-input') as HTMLInputElement | null;
+  if (!input) return;
+
+  input.value = formatLocalDateInput(state.currentWorkout.startTime);
+
+  if (!dateInputBound) {
+    input.addEventListener('change', handleWorkoutDateChange);
+    dateInputBound = true;
+  }
+
+  // showPicker is supported on modern Chromium/Firefox/Safari. Fall back
+  // to focus+click for older browsers (the input is offscreen, so click
+  // still surfaces the native picker on mobile).
+  try {
+    if (typeof input.showPicker === 'function') {
+      input.showPicker();
+      return;
+    }
+  } catch {
+    // showPicker can throw if not user-activated; fall through to click.
+  }
+  input.focus();
+  input.click();
+}
+
+function handleWorkoutDateChange(e: Event): void {
+  if (!state.currentWorkout) return;
+  const input = e.target as HTMLInputElement;
+  if (!input.value) return;
+
+  // Parse YYYY-MM-DD as local-date components and preserve the existing
+  // time-of-day so a 7pm workout stays at 7pm after a date swap.
+  const [y, m, d] = input.value.split('-').map(Number);
+  if (!y || !m || !d) return;
+
+  const original = new Date(state.currentWorkout.startTime);
+  const next = new Date(
+    y, m - 1, d,
+    original.getHours(), original.getMinutes(),
+    original.getSeconds(), original.getMilliseconds(),
+  );
+  const nextTs = next.getTime();
+  if (Number.isNaN(nextTs) || nextTs === state.currentWorkout.startTime) return;
+
+  state.currentWorkout.startTime = nextTs;
+  updateWorkoutTitle();
+  scheduleAutoSave();
+  showToast('Date updated');
 }
 
 export function startWorkout(): void {
@@ -162,6 +230,7 @@ export function startWorkout(): void {
   isEditingFromHistory = false;
   expandedNotes.clear();
   $('workout-title').textContent = "Today's Workout";
+  document.getElementById('edit-workout-date-btn')?.classList.add('hidden');
   showWorkoutScreen('workout-active');
   renderWorkout();
 }


### PR DESCRIPTION
Adds a small calendar-icon button next to the workout title — visible only when editing an existing workout — that opens the native date picker. Picking a new date updates `start_time` and triggers the existing autosave path; time-of-day is preserved so a 7pm session stays at 7pm.

Backend already supports `start_time` on `PUT /api/workouts/:id`, so no API changes needed.