### PR TITLE
fix: don't gate login screen transition on loadData

### DIFF
--- a/src/frontend/auth.ts
+++ b/src/frontend/auth.ts
@@ -105,8 +105,6 @@ export function createAuthSubmitHandler(onLoginSuccess: () => void): (e: Event) 
         const response = await api.login(username, password);
         currentUser = response.user;
       }
-      await loadData();
-      onLoginSuccess();
     } catch (error) {
       setSubmitLoading(false);
       if (error instanceof api.ApiError) {
@@ -114,7 +112,16 @@ export function createAuthSubmitHandler(onLoginSuccess: () => void): (e: Event) 
       } else {
         showAuthError('An error occurred. Please try again.');
       }
+      return;
     }
+
+    // Auth succeeded — switch to the main app immediately. loadData() can hang
+    // on a slow/stalled fetch, and gating the screen transition on it leaves
+    // the user staring at a spinner with a valid token already in localStorage
+    // (reload would then drop them straight into the app). Mirror init()'s
+    // optimistic path: show the app first, hydrate data in the background.
+    onLoginSuccess();
+    void loadData();
   };
 }
 


### PR DESCRIPTION
Fixes the "login hangs, reload works" bug. `api.login()` writes the JWT to localStorage immediately, but the submit handler awaited `loadData()` before calling `onLoginSuccess()`. `apiFetch` has no timeout, so a stalled fetch in `loadData` froze the spinner with a valid token already persisted — reloading then dropped the user into the cache-hydrate path in `init()` and they appeared logged in.

Switch to the main app as soon as auth succeeds, then run `loadData()` in the background. Mirrors what `init()` already does on the cache-hydrate path (`src/frontend/app.ts:189-213`).

Main change is in `src/frontend/auth.ts` `createAuthSubmitHandler`.