### PR TITLE
fix: cap fetch timeouts so Refresh can't spin forever

### DIFF
--- a/e2e/repro-refresh-bug.spec.ts
+++ b/e2e/repro-refresh-bug.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import {
+  authenticatePage,
+  createWorkoutViaApi,
+  setupTestUserWithExercises,
+  TestSetup,
+} from './helpers';
+
+test.describe('refresh bug repro', () => {
+  let setup: TestSetup;
+
+  test.beforeEach(async ({ request }) => {
+    setup = await setupTestUserWithExercises(request);
+  });
+
+  test('refresh recovers spinner when network hangs', async ({ page, request, context }) => {
+    test.setTimeout(30000);
+
+    await createWorkoutViaApi(request, setup.token, {
+      start_time: Date.now() - 60000,
+      end_time: Date.now() - 30000,
+      exercises: [{
+        name: 'Bench Press',
+        sets: [{ weight: 135, reps: 10, completed: true }],
+      }],
+    });
+
+    await authenticatePage(page, setup.token);
+    await expect(page.locator('#main-app')).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: 'History', exact: true }).click();
+    await expect(page.locator('.ring-2.ring-white')).toBeVisible({ timeout: 5000 });
+
+    // Now hang all subsequent /api/** requests
+    await context.route('**/api/**', async () => {
+      // Never resolve
+    });
+
+    const refreshBtn = page.locator('#tab-history .refresh-icon');
+    await refreshBtn.click();
+
+    // Spinner must clear within 20s even though network never responds.
+    // Pre-fix: stayed spinning forever.
+    await expect(refreshBtn).not.toHaveClass(/refreshing/, { timeout: 20000 });
+  });
+});

--- a/src/frontend/api.ts
+++ b/src/frontend/api.ts
@@ -37,6 +37,10 @@ export function isAuthenticated(): boolean {
   return !!getToken();
 }
 
+// Default cap so a stalled request can't lock the UI (e.g. Refresh spinner
+// stuck forever waiting on a fetch that never resolves on flaky networks).
+const DEFAULT_FETCH_TIMEOUT_MS = 10000;
+
 async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
   const token = getToken();
   const headers: Record<string, string> = {
@@ -51,6 +55,7 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
   const response = await fetch(`${API_BASE}${path}`, {
     ...options,
     headers,
+    signal: options.signal ?? AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -205,6 +210,7 @@ export async function updateWorkout(id: string, data: {
     method: 'PUT',
     headers,
     body: JSON.stringify(data),
+    signal: AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS),
   });
 
   if (response.status === 409) {

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -149,8 +149,13 @@ async function refresh(): Promise<void> {
   const btns = document.querySelectorAll('.refresh-icon');
   if (btns[0]?.classList.contains('refreshing')) return;
   btns.forEach(btn => btn.classList.add('refreshing'));
-  await handleRefresh();
-  btns.forEach(btn => btn.classList.remove('refreshing'));
+  try {
+    await handleRefresh();
+  } finally {
+    // try/finally so a thrown error inside handleRefresh can't leave the
+    // spinner pinned and block further refresh attempts.
+    btns.forEach(btn => btn.classList.remove('refreshing'));
+  }
 }
 
 // ==================== TAB SWITCH WIRING ====================

--- a/src/frontend/offline/client.ts
+++ b/src/frontend/offline/client.ts
@@ -15,11 +15,17 @@ function authHeaders(): Record<string, string> {
   return headers;
 }
 
+// Cap per-mutation requests so a stalled fetch can't pin the sync loop's
+// inFlight promise forever — that would deadlock callers like handleRefresh
+// that await flushNow() before reloading.
+const FETCH_TIMEOUT_MS = 10000;
+
 async function request(method: string, path: string, body: unknown): Promise<unknown> {
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers: authHeaders(),
     body: body === null || body === undefined ? undefined : JSON.stringify(body),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
     const parsed = await res.json().catch(() => ({}));


### PR DESCRIPTION
Refresh from the History/calendar tab spun indefinitely on flaky networks. `handleRefresh` awaits `flushNow()` then `loadData()`; both go through `fetch()`, which has no default timeout — one stalled request pins those promises forever with no recovery.

Fix: 10s `AbortSignal.timeout` on `apiFetch`, `updateWorkout`, and the offline sync's mutation `request`. `try/finally` around `await handleRefresh()` so a throw can't leave the spinner class pinned. Repro in `e2e/repro-refresh-bug.spec.ts` — hangs all `/api/**`, asserts the refresh icon's class clears within 20s.