### PR TITLE
feat: detect workout conflicts and prompt instead of silent clobbering

### DIFF
--- a/src/api/workouts.ts
+++ b/src/api/workouts.ts
@@ -69,7 +69,15 @@ app.put('/:id', async (c) => {
     return c.json({ error: 'Missing required fields' }, 400);
   }
 
-  const result = await queries.updateWorkout(c.env.DB, id, userId, body);
+  // updated_at is mandatory: it's the version this update is based on, and the
+  // only thing that lets the compare-and-swap reject a stale write. Without it
+  // we cannot distinguish an intentional update from one that would clobber a
+  // concurrent edit, so refuse rather than blind-overwrite.
+  if (typeof body.updated_at !== 'number') {
+    return c.json({ error: 'Missing required field: updated_at' }, 400);
+  }
+
+  const result = await queries.updateWorkout(c.env.DB, id, userId, { ...body, updated_at: body.updated_at });
 
   if (result.status === 'not_found') {
     return c.json({ error: 'Workout not found' }, 404);

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -807,7 +807,7 @@ describe('Exercise Notes', () => {
         }
       ]
     };
-    const result = await updateWorkout(env.DB, created.id, userId, updateData);
+    const result = await updateWorkout(env.DB, created.id, userId, { ...updateData, updated_at: created.updated_at });
 
     expect(result.status).toBe('success');
     const updated = (result as Extract<UpdateWorkoutResult, { status: 'success' }>).workout;
@@ -849,7 +849,7 @@ describe('Exercise Notes', () => {
         }
       ]
     };
-    const result = await updateWorkout(env.DB, created.id, userId, updateData);
+    const result = await updateWorkout(env.DB, created.id, userId, { ...updateData, updated_at: created.updated_at });
 
     expect(result.status).toBe('success');
     const updated = (result as Extract<UpdateWorkoutResult, { status: 'success' }>).workout;
@@ -1016,7 +1016,7 @@ describe('Exercise Notes', () => {
         }
       ]
     };
-    const result = await updateWorkout(env.DB, created.id, userId, updateData);
+    const result = await updateWorkout(env.DB, created.id, userId, { ...updateData, updated_at: created.updated_at });
 
     expect(result.status).toBe('success');
     const updated = (result as Extract<UpdateWorkoutResult, { status: 'success' }>).workout;
@@ -1105,8 +1105,9 @@ describe('Optimistic Locking', () => {
     };
     const created = await createWorkout(env.DB, userId, workout);
 
-    // Simulate external update (updates updated_at on server)
-    const externalUpdate: CreateWorkoutRequest = {
+    // Simulate external update (updates updated_at on server). Uses the create's
+    // version so it wins the compare-and-swap and bumps updated_at.
+    const externalUpdate: CreateWorkoutRequest & { updated_at: number } = {
       start_time: created.start_time,
       end_time: created.end_time,
       exercises: [
@@ -1116,6 +1117,7 @@ describe('Optimistic Locking', () => {
           sets: [{ weight: 135, reps: 10, completed: true }]
         }
       ],
+      updated_at: created.updated_at,
     };
     const externalResult = await updateWorkout(env.DB, created.id, userId, externalUpdate);
     expect(externalResult.status).toBe('success');
@@ -1143,7 +1145,7 @@ describe('Optimistic Locking', () => {
     expect(conflict.current.exercises[0].notes).toBe('Coach says: great form!');
   });
 
-  it('should allow update without updated_at (backward compatible)', async () => {
+  it('has no version-less escape hatch — a stale updated_at conflicts, never blind-overwrites', async () => {
     const workout: CreateWorkoutRequest = {
       start_time: Date.now(),
       end_time: Date.now() + 3600000,
@@ -1156,23 +1158,28 @@ describe('Optimistic Locking', () => {
     };
     const created = await createWorkout(env.DB, userId, workout);
 
-    // Update without sending updated_at - should always succeed (backward compat)
-    const updateData: CreateWorkoutRequest = {
+    // First update establishes a new version using the create's updated_at.
+    const first = await updateWorkout(env.DB, created.id, userId, {
       start_time: created.start_time,
       end_time: created.end_time,
       exercises: [
-        {
-          name: 'Bench Press',
-          notes: 'No version check',
-          sets: [{ weight: 135, reps: 10, completed: true }]
-        }
+        { name: 'Bench Press', notes: 'v2', sets: [{ weight: 135, reps: 10, completed: true }] }
       ],
-    };
-    const result = await updateWorkout(env.DB, created.id, userId, updateData);
+      updated_at: created.updated_at,
+    });
+    expect(first.status).toBe('success');
 
-    expect(result.status).toBe('success');
-    const updated = (result as Extract<UpdateWorkoutResult, { status: 'success' }>).workout;
-    expect(updated.exercises[0].notes).toBe('No version check');
+    // A second update still based on the ORIGINAL version must conflict. There
+    // is no path that skips the version check (the blind-overwrite branch is gone).
+    const stale = await updateWorkout(env.DB, created.id, userId, {
+      start_time: created.start_time,
+      end_time: created.end_time,
+      exercises: [
+        { name: 'Bench Press', notes: 'should be rejected', sets: [{ weight: 135, reps: 10, completed: true }] }
+      ],
+      updated_at: created.updated_at,
+    });
+    expect(stale.status).toBe('conflict');
   });
 
   it('should return not_found for non-existent workout', async () => {
@@ -1185,7 +1192,7 @@ describe('Optimistic Locking', () => {
         }
       ],
     };
-    const result = await updateWorkout(env.DB, 'nonexistent-id', userId, updateData);
+    const result = await updateWorkout(env.DB, 'nonexistent-id', userId, { ...updateData, updated_at: Date.now() });
 
     expect(result.status).toBe('not_found');
   });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -269,26 +269,19 @@ export type UpdateWorkoutResult =
   | { status: 'not_found' }
   | { status: 'conflict'; current: Workout };
 
-export async function updateWorkout(db: D1Database, id: string, userId: string, data: CreateWorkoutRequest & { updated_at?: number }): Promise<UpdateWorkoutResult> {
+export async function updateWorkout(db: D1Database, id: string, userId: string, data: CreateWorkoutRequest & { updated_at: number }): Promise<UpdateWorkoutResult> {
   const now = Date.now();
   const targetCategoriesJson = data.target_categories
     ? JSON.stringify(data.target_categories)
     : null;
 
-  // Atomic compare-and-swap: include updated_at in WHERE clause to prevent TOCTOU races
-  let result;
-  if (data.updated_at !== undefined) {
-    result = await db
-      .prepare('UPDATE workouts SET start_time = ?, end_time = ?, target_categories = ?, updated_at = ? WHERE id = ? AND user_id = ? AND updated_at = ?')
-      .bind(data.start_time, data.end_time ?? null, targetCategoriesJson, now, id, userId, data.updated_at)
-      .run();
-  } else {
-    // No version check (backward compatible) - still scope to user_id
-    result = await db
-      .prepare('UPDATE workouts SET start_time = ?, end_time = ?, target_categories = ?, updated_at = ? WHERE id = ? AND user_id = ?')
-      .bind(data.start_time, data.end_time ?? null, targetCategoriesJson, now, id, userId)
-      .run();
-  }
+  // Atomic compare-and-swap: updated_at is REQUIRED and included in the WHERE
+  // clause. There is no version-less update path — a write that doesn't know the
+  // version it's based on cannot prove it isn't clobbering a concurrent edit.
+  const result = await db
+    .prepare('UPDATE workouts SET start_time = ?, end_time = ?, target_categories = ?, updated_at = ? WHERE id = ? AND user_id = ? AND updated_at = ?')
+    .bind(data.start_time, data.end_time ?? null, targetCategoriesJson, now, id, userId, data.updated_at)
+    .run();
 
   if (result.meta.changes === 0) {
     // Either not found or version mismatch - check which

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -22,7 +22,8 @@ import {
   editWorkout, editWorkoutDate, resetWorkoutState,
   startSyncPolling, stopSyncPolling,
   editExerciseSetting, addExerciseSetting,
-  handleWorkoutSynced,
+  handleWorkoutSynced, handleSyncConflict,
+  resolveConflictKeepMine, resolveConflictLoadTheirs,
 } from './workout';
 import {
   showAddExercise, hideAddExercise, toggleAddExerciseSort, toggleAddExerciseCategory,
@@ -99,6 +100,7 @@ function startSyncEngine(): void {
     toast: showToast,
     onStatusChange: updateSyncIndicator,
     onWorkoutSynced: handleWorkoutSynced,
+    onConflict: handleSyncConflict,
   });
 }
 
@@ -337,6 +339,9 @@ async function init(): Promise<void> {
   stopRestTimer,
   // Refresh
   refresh,
+  // Conflict prompt
+  resolveConflictKeepMine,
+  resolveConflictLoadTheirs,
 };
 
 init();

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -19,7 +19,7 @@ import {
   toggleSetCompleted, toggleSetMissed, toggleNoteField,
   showAddSetForm, hideAddSetForm, saveSetInline, updateSet, deleteSet,
   showExerciseNotes, hideExerciseNotes, saveExerciseNotes,
-  editWorkout, editWorkoutDate, resetWorkoutState,
+  editWorkout, editWorkoutDate, resetWorkoutState, refreshCurrentWorkout,
   startSyncPolling, stopSyncPolling,
   editExerciseSetting, addExerciseSetting,
   handleWorkoutSynced, handleSyncConflict,
@@ -125,27 +125,33 @@ function renderActiveTab(): void {
 }
 
 // ==================== REFRESH HANDLER ====================
-// Refresh is "show me the server's truth" — it nukes local UI state and the
-// offline cache, then reloads from the network. This is the same recovery as
-// logout/login but without dropping auth, so users don't have to re-enter
-// credentials to escape a stale in-memory editing session (e.g. an SPA left
-// open across days that's still pointing at yesterday's editingWorkoutId).
+// Refresh pulls the server's truth — flush pending writes, clear the cache, and
+// reload from the network — while keeping you on the current view. If you're
+// editing a workout, that workout is re-fetched and re-rendered in place (so the
+// coach agent's changes show up) instead of dumping you back to the empty screen.
 async function handleRefresh(): Promise<void> {
   try {
     // Flush any pending offline writes first so they're not lost when we
     // clear the cache and re-read from server.
     try { await flushNow(); } catch (err) { console.warn('Flush before refresh failed:', err); }
 
-    state.currentWorkout = null;
-    state.editingWorkoutId = null;
-    resetWorkoutState();
+    // Remember what we're looking at so we can restore it after reloading.
+    const editingId = state.editingWorkoutId;
+
     try { await cacheClear(); } catch (err) { console.warn('cacheClear failed:', err); }
 
     await loadData();
 
     const activeTab = document.querySelector('.tab-content.active');
     if (activeTab?.id === 'tab-workout') {
-      showWorkoutScreen('workout-empty');
+      if (editingId) {
+        // Stay on the workout being edited; re-fetch it from the server.
+        // refreshCurrentWorkout handles the deleted-server-side case itself
+        // (cleans up and shows the empty screen).
+        await refreshCurrentWorkout();
+      }
+      // Nothing being edited (e.g. an in-progress new workout or the empty
+      // screen) — leave the current workout screen untouched.
     } else {
       renderActiveTab();
     }

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -104,6 +104,34 @@
       </div>
     </div>
 
+    <!-- Workout Conflict Modal: shown when the workout changed elsewhere (e.g. the
+         coach agent) while you had local edits. No backdrop-dismiss — pick a side. -->
+    <div id="workout-conflict-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center" aria-hidden="true">
+      <div class="absolute inset-0 bg-black/80"></div>
+      <div class="relative bg-swiss-card border border-swiss-border rounded-sm max-w-sm w-full mx-4 overflow-hidden">
+        <div class="flex items-center p-4 border-b border-swiss-border">
+          <h2 class="text-sm font-bold uppercase tracking-[0.2em]">Workout changed elsewhere</h2>
+        </div>
+        <div class="p-4">
+          <p class="text-sm text-swiss-text-secondary mb-4">This workout was updated somewhere else (likely your coach agent) while you were editing it. Pick which version to keep — they won't be merged.</p>
+          <div class="grid grid-cols-2 gap-3 mb-4 text-sm">
+            <div class="bg-swiss-surface border border-swiss-border rounded-sm p-3">
+              <div class="text-xs uppercase tracking-wider text-swiss-text-secondary mb-1">Your version</div>
+              <div id="conflict-mine-summary" class="text-white font-mono">—</div>
+            </div>
+            <div class="bg-swiss-surface border border-swiss-border rounded-sm p-3">
+              <div class="text-xs uppercase tracking-wider text-swiss-text-secondary mb-1">Their version</div>
+              <div id="conflict-theirs-summary" class="text-white font-mono">—</div>
+            </div>
+          </div>
+          <div class="flex gap-3">
+            <button onclick="app.resolveConflictKeepMine()" class="flex-1 border border-swiss-border hover:border-white text-white font-bold px-4 py-2 rounded-sm text-sm uppercase tracking-wider">Keep mine</button>
+            <button onclick="app.resolveConflictLoadTheirs()" class="flex-1 bg-swiss-red hover:bg-red-700 text-white font-bold px-4 py-2 rounded-sm text-sm uppercase tracking-wider">Load theirs</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- PR History Modal -->
     <div id="pr-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center" aria-hidden="true">
       <div class="absolute inset-0 bg-black/80" onclick="app.hidePRHistory()"></div>

--- a/src/frontend/offline/db.ts
+++ b/src/frontend/offline/db.ts
@@ -24,9 +24,11 @@ export interface Mutation {
   createdAt: number;
   attempts: number;
   lastError?: string;
-  // Set once if a 409 conflict has already been replayed with a fresh updated_at.
-  // A second conflict on the same mutation is terminal (drop + tell the truth).
-  replayedOnce?: boolean;
+  // Set when a 409 conflict is detected. A conflicted mutation is held in the
+  // queue and skipped by the drain (no auto-retry, no last-write-wins) until the
+  // user resolves it via the conflict prompt — keep mine (rebase + resend) or
+  // take theirs (drop). This is what stops the agent's edits from being clobbered.
+  conflicted?: boolean;
 }
 
 export type CacheKey = 'user' | 'workouts' | 'exercises' | 'prs';

--- a/src/frontend/offline/sync.test.ts
+++ b/src/frontend/offline/sync.test.ts
@@ -12,6 +12,7 @@ type Mutation = {
   createdAt: number;
   attempts: number;
   lastError?: string;
+  conflicted?: boolean;
 };
 
 // Mock the db module before importing sync so sync picks up the mock.
@@ -27,7 +28,10 @@ vi.mock('./db', () => ({
   },
 }));
 
-import { flushNow, __resetSyncForTests, startSync, stopSync, SyncHttpError } from './sync';
+import {
+  flushNow, __resetSyncForTests, startSync, stopSync, SyncHttpError,
+  resolveConflictKeepMine, resolveConflictTakeTheirs,
+} from './sync';
 
 function makeMutation(id: string, seq: number): Mutation {
   return {
@@ -154,5 +158,55 @@ describe('sync engine', () => {
     stopSync();
     expect(sent).toEqual(['a']);
     expect(state.queue).toEqual([]);
+  });
+
+  // A 409 must NOT silently last-write-wins anymore. The mutation is held in the
+  // queue (marked conflicted) and surfaced via onConflict so the user can choose.
+  it('409 holds the mutation as conflicted and fires onConflict (no auto-overwrite)', async () => {
+    state.queue = [makeMutation('w1', 1)];
+    const server = { id: 'w1', updated_at: 999 };
+    const send = vi.fn(async () => {
+      throw new SyncHttpError(409, { error: 'Conflict', current: server });
+    });
+    const onConflict = vi.fn();
+    startSync({ send, isOnline: () => true, onConflict }, 60_000);
+    await flushNow();
+    stopSync();
+    // Mutation is retained, marked conflicted — not dropped, not replayed.
+    expect(state.queue.length).toBe(1);
+    expect(state.queue[0].conflicted).toBe(true);
+    expect(onConflict).toHaveBeenCalledTimes(1);
+    expect(onConflict.mock.calls[0][1]).toEqual(server);
+  });
+
+  it('a conflicted mutation is skipped by the drain (no retry until resolved)', async () => {
+    state.queue = [{ ...makeMutation('w1', 1), conflicted: true }];
+    const send = vi.fn(async () => {});
+    startSync({ send, isOnline: () => true }, 60_000);
+    await flushNow();
+    stopSync();
+    expect(send).not.toHaveBeenCalled();
+    expect(state.queue.length).toBe(1);
+  });
+
+  it('resolveConflictKeepMine clears the flag, rebases updated_at, and resends', async () => {
+    state.queue = [{ ...makeMutation('w1', 1), isNew: false, body: { id: 'w1' }, conflicted: true }];
+    const sent: unknown[] = [];
+    const send = vi.fn(async (m: Mutation) => { sent.push(m.body); });
+    startSync({ send, isOnline: () => true }, 60_000);
+    await resolveConflictKeepMine('w1', 999);
+    // resolveConflictKeepMine kicks a flush; wait for it.
+    await flushNow();
+    stopSync();
+    expect(sent).toEqual([{ id: 'w1', updated_at: 999 }]);
+    expect(state.queue).toEqual([]);
+  });
+
+  it('resolveConflictTakeTheirs drops the local mutation', async () => {
+    state.queue = [{ ...makeMutation('w1', 1), conflicted: true }];
+    startSync({ send: vi.fn(async () => {}), isOnline: () => true }, 60_000);
+    await resolveConflictTakeTheirs('w1');
+    stopSync();
+    expect(state.queue.length).toBe(0);
   });
 });

--- a/src/frontend/offline/sync.ts
+++ b/src/frontend/offline/sync.ts
@@ -3,7 +3,8 @@
 // Responsibilities:
 // - Drain the IndexedDB mutation queue in FIFO order.
 // - Single-flight: only one flush runs at a time.
-// - On 409 (conflict), replay with last-write-wins semantics and surface a toast.
+// - On 409 (conflict), hold the mutation (marked `conflicted`) and surface it to
+//   the UI via onConflict so the user can pick a side. No silent last-write-wins.
 // - Listen to `online` events and a 60s interval for periodic retry.
 // - Expose a small API that workout.ts / app.ts can call without caring about the queue internals.
 
@@ -22,7 +23,7 @@ export interface SyncDeps {
   // Should throw on non-2xx with { status, body }.
   // Returns the parsed response body on success.
   send: (m: Mutation) => Promise<unknown>;
-  // User-visible notification (optional — used on 409 LWW replay).
+  // User-visible notification (optional).
   toast?: (message: string) => void;
   // Callback invoked whenever queue length or status changes (for UI indicator).
   onStatusChange?: (status: SyncStatus) => void;
@@ -32,6 +33,12 @@ export interface SyncDeps {
   // the parsed server response so the caller can update local state (e.g.
   // editingWorkoutUpdatedAt).
   onWorkoutSynced?: (mutation: Mutation, response: unknown) => void;
+  // Callback when a mutation hits a 409 conflict (the resource changed under us,
+  // e.g. the coach agent edited the workout). The mutation is held in the queue
+  // marked `conflicted`; the UI must prompt the user and then call
+  // resolveConflictKeepMine() or resolveConflictTakeTheirs() to unblock it.
+  // `current` is the server's current version of the resource (from the 409 body).
+  onConflict?: (mutation: Mutation, current: Record<string, unknown> | undefined) => void;
 }
 
 export interface SyncStatus {
@@ -99,7 +106,9 @@ async function doFlush(): Promise<void> {
     // Loop: fetch a snapshot, send each in order, re-snapshot if new ones arrive.
     // Bounded to avoid infinite loops under adversarial enqueue-during-flush.
     for (let pass = 0; pass < 5; pass++) {
-      const queue = await listQueue();
+      // Conflicted mutations are held until the user resolves them — they are
+      // invisible to the drain so they neither retry nor block other resources.
+      const queue = (await listQueue()).filter((m) => !m.conflicted);
       if (queue.length === 0) break;
 
       for (const m of queue) {
@@ -124,29 +133,15 @@ async function doFlush(): Promise<void> {
               return;
             }
             if (err.status === 409) {
-              // Last-write-wins: inject the server's current updated_at into
-              // our payload and retry once so the local edit overwrites the
-              // server. A second conflict is terminal — drop with a toast and
-              // let the next user edit converge.
+              // The resource changed under us (another device, or the coach
+              // agent). Do NOT silently overwrite either side. Hold the mutation
+              // (marked conflicted so the drain skips it) and surface it to the
+              // UI, which prompts the user to keep theirs or take the server's.
               const current = (err.body as { current?: Record<string, unknown> } | undefined)?.current;
-              if (current?.updated_at !== undefined && !m.replayedOnce) {
-                const bodyObj = (m.body && typeof m.body === 'object')
-                  ? (m.body as Record<string, unknown>)
-                  : null;
-                if (bodyObj) {
-                  bodyObj.updated_at = current.updated_at;
-                }
-                const replayed: Mutation = {
-                  ...m,
-                  body: bodyObj ?? m.body,
-                  replayedOnce: true,
-                };
-                await updateQueueEntry(replayed);
-                break;
-              }
-              deps.toast?.('A newer version from another device replaced your offline edit.');
-              await removeFromQueue(m.id);
+              const conflicted: Mutation = { ...m, conflicted: true };
+              await updateQueueEntry(conflicted);
               emitStatus({ pending: await queueLength() });
+              try { deps.onConflict?.(conflicted, current); } catch { /* non-fatal */ }
               continue;
             }
             if (err.status >= 400 && err.status < 500 && err.status !== 408 && err.status !== 429) {
@@ -214,6 +209,29 @@ export function stopSync(): void {
     window.removeEventListener('online', onlineHandler);
     onlineHandler = null;
   }
+}
+
+// Resolve a conflicted mutation by keeping the local (user's) version: rebase it
+// onto the server's current updated_at so the next send wins the compare-and-swap,
+// clear the conflicted flag, and kick a flush. No-op if the entry is gone.
+export async function resolveConflictKeepMine(id: string, serverUpdatedAt: number): Promise<void> {
+  const entry = (await listQueue()).find((m) => m.id === id);
+  if (!entry) return;
+  const bodyObj = (entry.body && typeof entry.body === 'object')
+    ? (entry.body as Record<string, unknown>)
+    : null;
+  if (bodyObj) bodyObj.updated_at = serverUpdatedAt;
+  await updateQueueEntry({ ...entry, body: bodyObj ?? entry.body, conflicted: false });
+  emitStatus({ pending: await queueLength(), lastError: null });
+  void flushNow();
+}
+
+// Resolve a conflicted mutation by taking the server's (their) version: drop the
+// local mutation entirely. The caller is responsible for loading server state
+// into the UI. No-op if the entry is gone.
+export async function resolveConflictTakeTheirs(id: string): Promise<void> {
+  await removeFromQueue(id);
+  emitStatus({ pending: await queueLength(), lastError: null });
 }
 
 // Test-only: reset module state between tests.

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -1,15 +1,15 @@
 import * as api from './api';
 import { ApiError } from './api';
 import type { Set as WorkoutSet } from './api';
-import type { MuscleGroup } from './api';
+import type { MuscleGroup, Workout } from './api';
 import type { CreateWorkoutRequest } from '../types';
 import { state, ALL_MUSCLE_GROUPS } from './state';
 import { $, escapeHtml, formatDate, getAllExercises, getTypeColor, getTypeLabel, showToast } from './helpers';
 import { loadData } from './data';
 import { showWorkoutScreen } from './nav';
 import { recalculateAllPRs } from './pr-calc';
-import { enqueue, type Mutation } from './offline/db';
-import { flushNow } from './offline/sync';
+import { enqueue, listQueue, type Mutation } from './offline/db';
+import { flushNow, resolveConflictKeepMine as syncKeepMine, resolveConflictTakeTheirs as syncTakeTheirs } from './offline/sync';
 import {
   buildWorkoutUpsert,
   buildWorkoutDelete,
@@ -26,6 +26,9 @@ let expandedNotes = new Set<string>();
 let selectedTargetCategories = new Set<MuscleGroup>();
 let isEditingCategories = false;
 let editingNotesExerciseIndex: number | null = null;
+// The server version awaiting a user decision in the conflict dialog. Non-null
+// only while the "Workout changed elsewhere" modal is open.
+let pendingConflict: Workout | null = null;
 
 // ==================== CATEGORY SELECTION ====================
 export function showCategorySelection(): void {
@@ -741,15 +744,29 @@ function handleVisibilityChange(): void {
   }
 }
 
-// Sync poll only handles the 404-on-server case (workout deleted elsewhere).
-// In single-device LWW mode there's no merge — auto-save PUTs are the
-// canonical write path; concurrent edits on a second device will be
-// resolved by last-write-wins on the next save.
+// Sync poll detects when the open workout changed underneath us — e.g. the
+// coach agent (MCP) edited it. If we have divergent local edits, prompt the user
+// to pick a side (never silently merge — see the killed 3-way-merge history).
+// If we have nothing local pending, quietly adopt the server's version so the
+// agent's change just appears. Also handles the 404 case (deleted elsewhere).
 async function syncPoll(): Promise<void> {
   if (!state.editingWorkoutId || isSyncPolling) return;
+  // Don't poll-prompt while a conflict dialog is already open.
+  if (pendingConflict) return;
   isSyncPolling = true;
   try {
-    await api.getWorkout(state.editingWorkoutId);
+    const workout = await api.getWorkout(state.editingWorkoutId);
+    // No known base, or server unchanged relative to it — nothing to reconcile.
+    if (editingWorkoutUpdatedAt === null || workout.updated_at === editingWorkoutUpdatedAt) {
+      return;
+    }
+    // Server moved ahead of our base. Prompt if we'd lose local work, else adopt.
+    if (await hasLocalDivergence()) {
+      showWorkoutConflict(workout);
+    } else {
+      adoptServerWorkout(workout);
+      showToast('Updated from server');
+    }
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       state.currentWorkout = null;
@@ -761,6 +778,103 @@ async function syncPoll(): Promise<void> {
     }
   } finally {
     isSyncPolling = false;
+  }
+}
+
+// We have un-synced local work if a debounced auto-save is pending/running or a
+// mutation for this workout is still queued (including one already conflicted).
+async function hasLocalDivergence(): Promise<boolean> {
+  if (autoSaveTimeout !== null || isAutoSaving) return true;
+  const id = state.editingWorkoutId;
+  if (!id) return false;
+  const queued = await listQueue();
+  return queued.some((m) => m.resourceId === id);
+}
+
+// Replace local editing state with the server's version. Used when the workout
+// changed remotely and either we have nothing local to lose, or the user chose
+// "Load theirs" in the conflict prompt.
+function adoptServerWorkout(workout: Workout): void {
+  state.currentWorkout = {
+    startTime: workout.start_time,
+    targetCategories: workout.target_categories,
+    exercises: JSON.parse(JSON.stringify(workout.exercises)),
+  };
+  editingWorkoutUpdatedAt = workout.updated_at;
+  renderWorkout();
+}
+
+// ==================== CONFLICT PROMPT ====================
+function summarize(exercises: { sets: unknown[] }[]): string {
+  const ex = exercises.length;
+  const sets = exercises.reduce((n, e) => n + e.sets.length, 0);
+  return `${ex} exercise${ex === 1 ? '' : 's'}, ${sets} set${sets === 1 ? '' : 's'}`;
+}
+
+// Show the "Workout changed elsewhere" modal. `current` is the server version.
+// Reached from two triggers: the poll (proactive) and a 409 during sync (at
+// write time, e.g. an offline edit landing late).
+export function showWorkoutConflict(current: Workout): void {
+  pendingConflict = current;
+  const mineEl = document.getElementById('conflict-mine-summary');
+  const theirsEl = document.getElementById('conflict-theirs-summary');
+  if (mineEl) mineEl.textContent = state.currentWorkout ? summarize(state.currentWorkout.exercises) : '(empty)';
+  if (theirsEl) theirsEl.textContent = summarize(current.exercises);
+  const modal = $('workout-conflict-modal');
+  modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
+}
+
+function hideWorkoutConflict(): void {
+  pendingConflict = null;
+  const modal = $('workout-conflict-modal');
+  modal.classList.add('hidden');
+  modal.setAttribute('aria-hidden', 'true');
+}
+
+// "Keep mine": rebase the local edit onto the server's current version so the
+// next save wins the compare-and-swap, then push it.
+export async function resolveConflictKeepMine(): Promise<void> {
+  const current = pendingConflict;
+  if (!current) return;
+  editingWorkoutUpdatedAt = current.updated_at;
+  const id = state.editingWorkoutId;
+  if (id) {
+    const mutationId = `workout.upsert:${id}`;
+    const queued = (await listQueue()).find((m) => m.id === mutationId);
+    if (queued) {
+      // A mutation is already queued (possibly conflicted) — rebase + resend it.
+      await syncKeepMine(mutationId, current.updated_at);
+    } else {
+      // Poll caught the conflict before anything was queued — enqueue current state.
+      scheduleAutoSave();
+    }
+  }
+  hideWorkoutConflict();
+  showToast('Kept your version');
+}
+
+// "Load theirs": discard the local edit and adopt the server's version.
+export async function resolveConflictLoadTheirs(): Promise<void> {
+  const current = pendingConflict;
+  if (!current) return;
+  // Cancel any pending auto-save so it can't re-enqueue the discarded local edit.
+  if (autoSaveTimeout) { clearTimeout(autoSaveTimeout); autoSaveTimeout = null; }
+  const id = state.editingWorkoutId;
+  if (id) await syncTakeTheirs(`workout.upsert:${id}`);
+  adoptServerWorkout(current);
+  hideWorkoutConflict();
+  showToast('Loaded latest version');
+}
+
+// Wired to the sync engine's onConflict (a 409 during background flush). Routes
+// the currently-edited workout to the prompt; otherwise informs the user.
+export function handleSyncConflict(mutation: Mutation, current: Record<string, unknown> | undefined): void {
+  if (!current) return;
+  if (mutation.resourceId === state.editingWorkoutId) {
+    showWorkoutConflict(current as unknown as Workout);
+  } else {
+    showToast('A workout changed elsewhere — open it to resolve');
   }
 }
 

--- a/src/frontend/workout.ts
+++ b/src/frontend/workout.ts
@@ -289,23 +289,24 @@ async function autoSaveWorkout(): Promise<void> {
 
     let resourceId: string;
     let isNew: boolean;
-    if (state.editingWorkoutId) {
+    if (state.editingWorkoutId && editingWorkoutUpdatedAt !== null) {
+      // Known existing workout — PUT with the version we're based on. The
+      // backend now requires updated_at and rejects a PUT without it.
       resourceId = state.editingWorkoutId;
       isNew = false;
       const originalWorkout = state.history.find(w => w.id === state.editingWorkoutId);
       if (originalWorkout?.end_time) {
         workoutData.end_time = originalWorkout.end_time;
       }
-      if (editingWorkoutUpdatedAt !== null) {
-        workoutData.updated_at = editingWorkoutUpdatedAt;
-      }
+      workoutData.updated_at = editingWorkoutUpdatedAt;
     } else {
-      // New workout: assign a client-generated id so the outbox can POST
-      // with idempotent semantics and subsequent edits route to the same resource.
-      resourceId = newClientId();
+      // New workout, or one created offline that the server hasn't confirmed
+      // yet (no base updated_at). (Re)POST with a stable client-generated id —
+      // POST is idempotent on the id, so re-sending is safe and returns the
+      // server's updated_at. Never PUT without a base version.
+      resourceId = state.editingWorkoutId ?? newClientId();
       isNew = true;
       state.editingWorkoutId = resourceId;
-      editingWorkoutUpdatedAt = null;
     }
 
     await enqueue(buildWorkoutUpsert(resourceId, isNew, workoutData));

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,3 +1,12 @@
+// Carries the HTTP status and parsed body so callers can react to specific
+// failures (notably 409 conflicts from the backend's compare-and-swap).
+export class WorkoutApiError extends Error {
+  constructor(public status: number, public body: unknown, message?: string) {
+    super(message ?? `API error ${status}`);
+    this.name = 'WorkoutApiError';
+  }
+}
+
 export class WorkoutApiClient {
   private baseUrl: string;
   private apiKey: string;
@@ -19,8 +28,10 @@ export class WorkoutApiClient {
     });
 
     if (!res.ok) {
-      const body = await res.text();
-      throw new Error(`API error ${res.status}: ${body}`);
+      const text = await res.text();
+      let parsed: unknown = text;
+      try { parsed = JSON.parse(text); } catch { /* not JSON — keep raw text */ }
+      throw new WorkoutApiError(res.status, parsed, `API error ${res.status}: ${text}`);
     }
 
     return res.json() as Promise<T>;

--- a/src/mcp/tools/workouts.ts
+++ b/src/mcp/tools/workouts.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { WorkoutApiClient } from '../client.js';
+import { type WorkoutApiClient, WorkoutApiError } from '../client.js';
 
 function formatDate(ms: number): string {
   return new Date(ms).toLocaleDateString('en-US', {
@@ -110,10 +110,45 @@ export function registerWorkoutTools(server: McpServer, client: WorkoutApiClient
       },
     },
     async ({ id, ...data }) => {
-      const workout = await client.updateWorkout(id, data);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(workout, null, 2) }],
-      };
+      // Read current state so we can send its updated_at and hit the backend's
+      // compare-and-swap path. Without this the PUT takes the blind-overwrite
+      // branch and silently clobbers an edit the user just made in the app.
+      let updatedAt: number | undefined;
+      try {
+        const current = await client.getWorkout(id) as { updated_at?: number } | null;
+        updatedAt = current?.updated_at;
+      } catch {
+        // If the read fails (e.g. 404), let the update surface the real error.
+      }
+
+      try {
+        const workout = await client.updateWorkout(
+          id,
+          updatedAt !== undefined ? { ...data, updated_at: updatedAt } : data,
+        );
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(workout, null, 2) }],
+        };
+      } catch (err) {
+        if (err instanceof WorkoutApiError && err.status === 409) {
+          // Someone (almost certainly the user in the app) changed this workout
+          // between our read and write. Do NOT retry blindly — surface the
+          // current server state so the model can reconcile and re-apply.
+          const serverCurrent = (err.body as { current?: unknown } | undefined)?.current;
+          return {
+            isError: true,
+            content: [{
+              type: 'text' as const,
+              text:
+                `Conflict: workout ${id} was modified since you read it (likely the user edited it in the app). ` +
+                `Your update was NOT applied, to avoid clobbering their change.\n\n` +
+                `Current server state:\n${JSON.stringify(serverCurrent ?? null, null, 2)}\n\n` +
+                `Reconcile your intended change with this current state, then call update_workout again.`,
+            }],
+          };
+        }
+        throw err;
+      }
     },
   );
 }


### PR DESCRIPTION
Fixes edits getting clobbered/reverted when both the app and the MCP coach agent touch the same workout, and tightens the write path so it can't happen again.

**Root cause:** two writers + full-document PUT. The agent never sent `updated_at` (took the backend's blind-overwrite branch) and the app silently last-write-wins on 409 — guaranteed clobbering depending on who wrote last.

**This PR (three commits):**
1. **Conflict detection + prompt** — agent now participates in compare-and-swap and surfaces 409 to the model; the app holds conflicts instead of silent LWW and shows a **Keep mine / Load theirs** prompt (whole-workout, no field merge — per the killed 3-way-merge history #99/#102/#105). The 5s poll detects remote changes proactively.
2. **Lock down the backend** — PUT now 400s without a numeric `updated_at`; `updateWorkout` has no version-less path. Frontend only PUTs with a known base version, else (re)POSTs idempotently.
3. **Refresh stays on the page** — instead of dumping to the empty screen, Refresh reloads from the server and re-renders the workout you're editing in place.

Review focus: `offline/sync.ts` (409 path), `workout.ts` `syncPoll`/conflict handlers, and the `updateWorkout` CAS change. Not auto-merging given the merge-corruption history — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)