### PR TITLE
fix: stop silently dropping data when a slow load aborts

### DIFF
--- a/e2e/repro-refresh-bug.spec.ts
+++ b/e2e/repro-refresh-bug.spec.ts
@@ -14,7 +14,12 @@ test.describe('refresh bug repro', () => {
   });
 
   test('refresh recovers spinner when network hangs', async ({ page, request, context }) => {
-    test.setTimeout(30000);
+    // The spinner clears when the read fetch aborts, which is bounded by
+    // DEFAULT_FETCH_TIMEOUT_MS (30s) — raised from 10s to stop the large
+    // /workouts payload from aborting on real connections and silently
+    // dropping data. The original bug this guards against was "spins forever";
+    // bounded-at-30s still proves recovery. Budget must exceed the expect below.
+    test.setTimeout(50000);
 
     await createWorkoutViaApi(request, setup.token, {
       start_time: Date.now() - 60000,
@@ -39,8 +44,10 @@ test.describe('refresh bug repro', () => {
     const refreshBtn = page.locator('#tab-history .refresh-icon');
     await refreshBtn.click();
 
-    // Spinner must clear within 20s even though network never responds.
-    // Pre-fix: stayed spinning forever.
-    await expect(refreshBtn).not.toHaveClass(/refreshing/, { timeout: 20000 });
+    // Spinner must clear once the read aborts (~30s) even though the network
+    // never responds. Pre-fix: stayed spinning forever. 36s = the 30s fetch
+    // timeout plus generous margin for the abort to propagate through
+    // handleRefresh on a slow CI runner.
+    await expect(refreshBtn).not.toHaveClass(/refreshing/, { timeout: 36000 });
   });
 });

--- a/src/frontend/api.ts
+++ b/src/frontend/api.ts
@@ -39,7 +39,14 @@ export function isAuthenticated(): boolean {
 
 // Default cap so a stalled request can't lock the UI (e.g. Refresh spinner
 // stuck forever waiting on a fetch that never resolves on flaky networks).
-const DEFAULT_FETCH_TIMEOUT_MS = 10000;
+//
+// 10s was too aggressive: the GET /workouts payload is large (every workout with
+// all nested sets) and takes ~6s even on a fast connection, so real mobile
+// connections routinely crossed 10s and the load aborted, silently leaving stale
+// data on screen. 30s gives slow connections room to finish while still bounding
+// a genuinely dead request. The real fix is shrinking that payload (pagination);
+// tracked as a follow-up.
+const DEFAULT_FETCH_TIMEOUT_MS = 30000;
 
 async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
   const token = getToken();

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -124,6 +124,42 @@ function renderActiveTab(): void {
   // no re-render needed when background data lands.
 }
 
+// ==================== DATA LOAD + ERROR SURFACING ====================
+function showLoadError(): void {
+  $('load-error-banner').classList.remove('hidden');
+}
+
+function hideLoadError(): void {
+  $('load-error-banner').classList.add('hidden');
+}
+
+// Load fresh data and re-render the active tab. On failure (e.g. a slow-network
+// fetch aborted by its timeout), surface a retry banner instead of silently
+// leaving stale data on screen. This is auth-agnostic: a data-load failure must
+// NOT log the user out — auth is validated separately via getCurrentUser().
+async function loadDataAndRender(): Promise<void> {
+  try {
+    await loadData();
+    hideLoadError();
+    renderActiveTab();
+  } catch (error) {
+    console.error('Failed to load data:', error);
+    showLoadError();
+  }
+}
+
+// Retry handler wired to the load-error banner's Retry button. Spins the refresh
+// icons for feedback and re-attempts the load.
+async function retryLoad(): Promise<void> {
+  const btns = document.querySelectorAll('.refresh-icon');
+  btns.forEach(btn => btn.classList.add('refreshing'));
+  try {
+    await loadDataAndRender();
+  } finally {
+    btns.forEach(btn => btn.classList.remove('refreshing'));
+  }
+}
+
 // ==================== REFRESH HANDLER ====================
 // Refresh pulls the server's truth — flush pending writes, clear the cache, and
 // reload from the network — while keeping you on the current view. If you're
@@ -142,6 +178,7 @@ async function handleRefresh(): Promise<void> {
 
     await loadData();
 
+    hideLoadError();
     const activeTab = document.querySelector('.tab-content.active');
     if (activeTab?.id === 'tab-workout') {
       if (editingId) {
@@ -159,6 +196,7 @@ async function handleRefresh(): Promise<void> {
   } catch (error) {
     console.error('Failed to refresh:', error);
     showToast('Refresh failed');
+    showLoadError();
   }
 }
 
@@ -193,8 +231,9 @@ async function init(): Promise<void> {
     // Background data load: must re-render the active tab when it resolves,
     // otherwise a user who clicks History/Exercises/PRs before loadData
     // finishes sees an empty view that never updates (auth.ts can't do this
-    // itself without an import cycle into the render modules).
-    void loadData().then(renderActiveTab);
+    // itself without an import cycle into the render modules). A failed load
+    // surfaces a retry banner rather than leaving an empty view forever.
+    void loadDataAndRender();
   }));
 
   if (api.isAuthenticated()) {
@@ -223,21 +262,24 @@ async function init(): Promise<void> {
       startSyncPolling();
       startSyncEngine();
       if (online) {
-        // Background refresh + auth validation. Failure kicks user back to auth.
-        // Re-render the active tab after loadData so a user viewing History
-        // sees freshly-fetched workouts replace the cached snapshot, not the
-        // other way around.
+        // Background auth validation + data refresh. These are handled
+        // SEPARATELY: only an auth failure (invalid/expired token) should kick
+        // the user back to the login screen. A data-load failure (e.g. a slow
+        // network aborting the big /workouts fetch) must keep the user in the
+        // app on cached data and surface a retry banner — logging them out over
+        // a transient network blip would be a far worse experience.
         void (async () => {
           try {
             const user = await api.getCurrentUser();
             setCurrentUser(user);
-            await loadData();
-            renderActiveTab();
           } catch {
             api.logout();
             stopSync();
             showAuthScreen();
+            return;
           }
+          // Auth is valid — refresh data, surfacing failures without logout.
+          await loadDataAndRender();
         })();
       }
       return;
@@ -252,14 +294,19 @@ async function init(): Promise<void> {
     try {
       const user = await api.getCurrentUser();
       setCurrentUser(user);
-      await loadData();
-      showMainApp(handleRefresh);
-      startSyncPolling();
-      startSyncEngine();
     } catch {
+      // Auth validation failed — token is bad. Back to login.
       api.logout();
       showAuthScreen();
+      return;
     }
+    // Auth is valid: enter the app, then load data. A data-load failure here
+    // shows the app (empty) with a retry banner rather than bouncing a
+    // legitimately-logged-in user back to the auth screen.
+    showMainApp(handleRefresh);
+    startSyncPolling();
+    startSyncEngine();
+    await loadDataAndRender();
   } else {
     showAuthScreen();
   }
@@ -345,6 +392,8 @@ async function init(): Promise<void> {
   stopRestTimer,
   // Refresh
   refresh,
+  // Retry a failed data load (load-error banner button)
+  retryLoad,
   // Conflict prompt
   resolveConflictKeepMine,
   resolveConflictLoadTheirs,

--- a/src/frontend/app.ts
+++ b/src/frontend/app.ts
@@ -124,39 +124,26 @@ function renderActiveTab(): void {
   // no re-render needed when background data lands.
 }
 
-// ==================== DATA LOAD + ERROR SURFACING ====================
-function showLoadError(): void {
-  $('load-error-banner').classList.remove('hidden');
-}
-
-function hideLoadError(): void {
-  $('load-error-banner').classList.add('hidden');
-}
-
+// ==================== DATA LOAD ====================
 // Load fresh data and re-render the active tab. On failure (e.g. a slow-network
-// fetch aborted by its timeout), surface a retry banner instead of silently
-// leaving stale data on screen. This is auth-agnostic: a data-load failure must
-// NOT log the user out — auth is validated separately via getCurrentUser().
+// fetch aborted by its timeout) we DON'T nag with a sticky banner — we just
+// re-render with whatever state we have so cached data stays on screen, and show
+// a brief auto-dismissing toast only when there's genuinely nothing to show.
+// This is auth-agnostic: a data-load failure must NOT log the user out — auth is
+// validated separately via getCurrentUser().
 async function loadDataAndRender(): Promise<void> {
   try {
     await loadData();
-    hideLoadError();
     renderActiveTab();
   } catch (error) {
     console.error('Failed to load data:', error);
-    showLoadError();
-  }
-}
-
-// Retry handler wired to the load-error banner's Retry button. Spins the refresh
-// icons for feedback and re-attempts the load.
-async function retryLoad(): Promise<void> {
-  const btns = document.querySelectorAll('.refresh-icon');
-  btns.forEach(btn => btn.classList.add('refreshing'));
-  try {
-    await loadDataAndRender();
-  } finally {
-    btns.forEach(btn => btn.classList.remove('refreshing'));
+    // Keep showing whatever we already have (cache / prior load).
+    renderActiveTab();
+    // Only surface a message if we have nothing at all — otherwise the cached
+    // data on screen is fine and a toast would just be noise.
+    if (state.history.length === 0) {
+      showToast('Couldn\'t load — check connection');
+    }
   }
 }
 
@@ -178,7 +165,6 @@ async function handleRefresh(): Promise<void> {
 
     await loadData();
 
-    hideLoadError();
     const activeTab = document.querySelector('.tab-content.active');
     if (activeTab?.id === 'tab-workout') {
       if (editingId) {
@@ -196,7 +182,6 @@ async function handleRefresh(): Promise<void> {
   } catch (error) {
     console.error('Failed to refresh:', error);
     showToast('Refresh failed');
-    showLoadError();
   }
 }
 
@@ -392,8 +377,6 @@ async function init(): Promise<void> {
   stopRestTimer,
   // Refresh
   refresh,
-  // Retry a failed data load (load-error banner button)
-  retryLoad,
   // Conflict prompt
   resolveConflictKeepMine,
   resolveConflictLoadTheirs,

--- a/src/frontend/data.test.ts
+++ b/src/frontend/data.test.ts
@@ -1,0 +1,79 @@
+// Tests for loadData()'s failure contract. The api and offline/db modules are
+// mocked so these run in the Cloudflare Workers test pool with no real network
+// or IndexedDB.
+//
+// Regression guard: loadData() used to swallow fetch errors and return void,
+// which meant a slow-network fetch aborted by its timeout silently left stale
+// data on screen (the newest month's workouts never appeared). loadData() now
+// THROWS on failure so callers can surface a retry affordance.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const api = {
+  getWorkouts: vi.fn(),
+  getCustomExercises: vi.fn(),
+  getAllPRs: vi.fn(),
+};
+vi.mock('./api', () => ({
+  getWorkouts: (...a: unknown[]) => api.getWorkouts(...a),
+  getCustomExercises: (...a: unknown[]) => api.getCustomExercises(...a),
+  getAllPRs: (...a: unknown[]) => api.getAllPRs(...a),
+}));
+
+const cache: { sets: Record<string, unknown> } = { sets: {} };
+vi.mock('./offline/db', () => ({
+  cacheGet: async (k: string) => cache.sets[k],
+  cacheSet: async (k: string, v: unknown) => {
+    cache.sets[k] = v;
+  },
+}));
+
+import { loadData } from './data';
+import { state } from './state';
+
+beforeEach(() => {
+  api.getWorkouts.mockReset();
+  api.getCustomExercises.mockReset();
+  api.getAllPRs.mockReset();
+  cache.sets = {};
+  state.history = [];
+  state.customExercises = [];
+  state.allPRs = [];
+});
+
+describe('loadData', () => {
+  it('populates state and write-through caches on success', async () => {
+    const workouts = [{ id: 'w1', start_time: 1, exercises: [] }];
+    const exercises = [{ id: 'e1', name: 'Bench' }];
+    const prs = [{ exercise_name: 'Bench' }];
+    api.getWorkouts.mockResolvedValue(workouts);
+    api.getCustomExercises.mockResolvedValue(exercises);
+    api.getAllPRs.mockResolvedValue(prs);
+
+    await loadData();
+
+    expect(state.history).toEqual(workouts);
+    expect(state.customExercises).toEqual(exercises);
+    expect(state.allPRs).toEqual(prs);
+    expect(cache.sets.workouts).toEqual(workouts);
+  });
+
+  it('THROWS when the workouts fetch fails (e.g. aborted by timeout)', async () => {
+    api.getWorkouts.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    api.getCustomExercises.mockResolvedValue([]);
+    api.getAllPRs.mockResolvedValue([]);
+
+    await expect(loadData()).rejects.toThrow();
+  });
+
+  it('does not clobber existing state when the load fails', async () => {
+    const existing = [{ id: 'cached', start_time: 1, exercises: [] }];
+    state.history = existing as typeof state.history;
+    api.getWorkouts.mockRejectedValue(new Error('network down'));
+    api.getCustomExercises.mockResolvedValue([]);
+    api.getAllPRs.mockResolvedValue([]);
+
+    await expect(loadData()).rejects.toThrow();
+    // Stale-but-present data is preferable to wiped state on a failed refresh.
+    expect(state.history).toEqual(existing);
+  });
+});

--- a/src/frontend/data.ts
+++ b/src/frontend/data.ts
@@ -2,28 +2,33 @@ import * as api from './api';
 import { state } from './state';
 import { cacheGet, cacheSet } from './offline/db';
 
+// Loads workouts/exercises/PRs into state and write-through caches them.
+//
+// THROWS on failure (network error, or a fetch aborted by its timeout on a slow
+// connection). Callers MUST handle the rejection — historically this swallowed
+// errors and returned void, which meant a timed-out load silently left stale
+// state on screen (e.g. the newest month's workouts never appeared because the
+// big /workouts payload aborted before it arrived). Surfacing the error lets the
+// caller show a retry affordance instead of pretending the load succeeded.
 export async function loadData(): Promise<void> {
+  const [workouts, exercises, prs] = await Promise.all([
+    api.getWorkouts(),
+    api.getCustomExercises(),
+    api.getAllPRs(),
+  ]);
+  state.history = workouts;
+  state.customExercises = exercises;
+  state.allPRs = prs;
+  // Write-through cache so the next cold start can hydrate offline. Best-effort:
+  // a cache write failure must not fail the load itself.
   try {
-    const [workouts, exercises, prs] = await Promise.all([
-      api.getWorkouts(),
-      api.getCustomExercises(),
-      api.getAllPRs(),
+    await Promise.all([
+      cacheSet('workouts', workouts),
+      cacheSet('exercises', exercises),
+      cacheSet('prs', prs),
     ]);
-    state.history = workouts;
-    state.customExercises = exercises;
-    state.allPRs = prs;
-    // Write-through cache so the next cold start can hydrate offline.
-    try {
-      await Promise.all([
-        cacheSet('workouts', workouts),
-        cacheSet('exercises', exercises),
-        cacheSet('prs', prs),
-      ]);
-    } catch (err) {
-      console.warn('Failed to update offline cache:', err);
-    }
-  } catch (error) {
-    console.error('Failed to load data:', error);
+  } catch (err) {
+    console.warn('Failed to update offline cache:', err);
   }
 }
 

--- a/src/frontend/exercises-tab.ts
+++ b/src/frontend/exercises-tab.ts
@@ -553,10 +553,16 @@ export async function saveExercise(): Promise<void> {
     // server-propagated rename in historical workouts. If we render first, PR
     // stars are computed against stale history where the exercise still has
     // the old name, producing false PR stars for sets that tie existing
-    // records. If offline, loadData will fail silently and we keep the
-    // optimistic local state.
+    // records. If offline or the load fails, swallow it here and keep the
+    // optimistic local state — the rename itself is already enqueued, so a
+    // failed history refresh must not abort the save flow. (loadData() throws
+    // on failure; this call site deliberately ignores that.)
     if (typeof navigator === 'undefined' || navigator.onLine !== false) {
-      await loadData();
+      try {
+        await loadData();
+      } catch (err) {
+        console.warn('History refresh after rename failed; keeping local state:', err);
+      }
     }
 
     if (oldName && oldName !== name && state.currentWorkout) {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -78,6 +78,14 @@
       <div class="pull-spinner"></div>
     </div>
 
+    <!-- Data load-failure banner. Shown when loadData() fails (e.g. slow network
+         aborts the fetch) so a failed load never silently leaves stale data on
+         screen with no way to recover short of a full reload. -->
+    <div id="load-error-banner" class="hidden fixed top-16 left-1/2 -translate-x-1/2 z-50 bg-swiss-red text-white px-4 py-2 rounded-sm text-sm font-bold uppercase tracking-wider flex items-center gap-3 shadow-lg">
+      <span>Couldn't load your data</span>
+      <button onclick="app.retryLoad()" class="underline hover:no-underline">Retry</button>
+    </div>
+
     <!-- Auto-save toast notification -->
     <div id="save-toast" class="hidden fixed top-20 left-1/2 transform -translate-x-1/2 bg-white text-black px-4 py-2 rounded-sm z-50 transition-opacity duration-300 font-bold text-sm uppercase tracking-wider">
       Saved

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -78,14 +78,6 @@
       <div class="pull-spinner"></div>
     </div>
 
-    <!-- Data load-failure banner. Shown when loadData() fails (e.g. slow network
-         aborts the fetch) so a failed load never silently leaves stale data on
-         screen with no way to recover short of a full reload. -->
-    <div id="load-error-banner" class="hidden fixed top-16 left-1/2 -translate-x-1/2 z-50 bg-swiss-red text-white px-4 py-2 rounded-sm text-sm font-bold uppercase tracking-wider flex items-center gap-3 shadow-lg">
-      <span>Couldn't load your data</span>
-      <button onclick="app.retryLoad()" class="underline hover:no-underline">Retry</button>
-    </div>
-
     <!-- Auto-save toast notification -->
     <div id="save-toast" class="hidden fixed top-20 left-1/2 transform -translate-x-1/2 bg-white text-black px-4 py-2 rounded-sm z-50 transition-opacity duration-300 font-bold text-sm uppercase tracking-wider">
       Saved


### PR DESCRIPTION
**Symptom:** the newest workouts (e.g. the current month) silently never appeared; the UI showed a stale snapshot.

**Root cause:** the 10s fetch timeout from #110 aborted the large `GET /workouts` payload. It's 225KB and takes ~6s even from a fast connection, so slower connections crossed 10s; `loadData()` then failed, swallowed the error, and `state.history` was never updated. Confirmed by diffing the live prod bundle (has the 10s `AbortSignal.timeout`) against an older working preview (no timeout).

**Fix:**
- Raise the read timeout 10s → 30s so the big payload finishes on real connections.
- `loadData()` now throws on failure instead of silently swallowing.
- On a load failure the app keeps whatever data it already has (cache / prior load) on screen and shows at most a brief auto-dismissing toast — no sticky banner, no logout. Auth is validated separately from data loading, so a transient network failure never bounces a logged-in user to the login screen.

**Follow-up worth filing:** `/workouts` ships every workout with all nested sets in one 225KB / ~6s response. Paginating or trimming it is the real "make this zippy" fix and would also stop slow connections from failing the refresh at all.