### PR TITLE
perf: batch getAllWorkouts to kill the N+1 query explosion

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -4,6 +4,7 @@ import {
   createUser,
   createWorkout,
   getWorkout,
+  getAllWorkouts,
   updateWorkout,
   createCustomExercise,
   updateCustomExercise,
@@ -1799,5 +1800,93 @@ describe('Exercise Settings', () => {
     const found = deleted.find(e => e.id === exercise.id);
     expect(found).toBeDefined();
     expect(found!.settings).toBeUndefined();
+  });
+});
+
+describe('getAllWorkouts (batched assembly)', () => {
+  let userId: string;
+  const testUsername = 'testuser_getall';
+
+  beforeEach(async () => {
+    await env.DB.prepare('DELETE FROM users WHERE username = ?').bind(testUsername).run();
+    const user = await createUser(env.DB, testUsername, 'hash123');
+    userId = user.id;
+  });
+
+  it('returns an empty array for a user with no workouts', async () => {
+    const all = await getAllWorkouts(env.DB, userId);
+    expect(all).toEqual([]);
+  });
+
+  it('returns workouts newest-first with exercises and sets in position order', async () => {
+    const older: CreateWorkoutRequest = {
+      start_time: Date.now() - 86400000,
+      exercises: [
+        { name: 'Squat', sets: [{ weight: 200, reps: 5, completed: true }] },
+      ],
+    };
+    const newer: CreateWorkoutRequest = {
+      start_time: Date.now(),
+      exercises: [
+        { name: 'Bench Press', sets: [
+          { weight: 100, reps: 10, completed: true },
+          { weight: 110, reps: 8, completed: true },
+        ] },
+        { name: 'Row', sets: [{ weight: 90, reps: 12, completed: true }] },
+      ],
+    };
+    await createWorkout(env.DB, userId, older);
+    await createWorkout(env.DB, userId, newer);
+
+    const all = await getAllWorkouts(env.DB, userId);
+
+    expect(all).toHaveLength(2);
+    // Newest first.
+    expect(all[0].start_time).toBeGreaterThan(all[1].start_time);
+    // Exercises preserved in order.
+    expect(all[0].exercises.map(e => e.name)).toEqual(['Bench Press', 'Row']);
+    // Sets preserved in order within an exercise.
+    expect(all[0].exercises[0].sets.map(s => s.weight)).toEqual([100, 110]);
+    expect(all[0].exercises[0].sets.map(s => s.reps)).toEqual([10, 8]);
+    expect(all[1].exercises[0].name).toBe('Squat');
+  });
+
+  it('matches single-workout getWorkout output exactly (incl. PR flags)', async () => {
+    // Two workouts so a PR is detected on the second; then assert the batched
+    // getAllWorkouts produces the same object as the per-workout getWorkout.
+    await createWorkout(env.DB, userId, {
+      start_time: Date.now() - 86400000,
+      exercises: [{ name: 'Deadlift', sets: [{ weight: 300, reps: 5, completed: true }] }],
+    });
+    const second = await createWorkout(env.DB, userId, {
+      start_time: Date.now(),
+      exercises: [{ name: 'Deadlift', sets: [{ weight: 300, reps: 8, completed: true }] }],
+    });
+
+    const viaSingle = await getWorkout(env.DB, second.id, userId);
+    const all = await getAllWorkouts(env.DB, userId);
+    const viaAll = all.find(w => w.id === second.id);
+
+    expect(viaAll).toEqual(viaSingle);
+    // The heavier-rep set at the same weight is a PR.
+    expect(viaAll!.exercises[0].sets[0].isPR).toBe(true);
+  });
+
+  it('scopes strictly to the requesting user', async () => {
+    const otherUsername = 'testuser_getall_other';
+    await env.DB.prepare('DELETE FROM users WHERE username = ?').bind(otherUsername).run();
+    const other = await createUser(env.DB, otherUsername, 'hash123');
+    await createWorkout(env.DB, other.id, {
+      start_time: Date.now(),
+      exercises: [{ name: 'Curl', sets: [{ weight: 30, reps: 12, completed: true }] }],
+    });
+    await createWorkout(env.DB, userId, {
+      start_time: Date.now(),
+      exercises: [{ name: 'Press', sets: [{ weight: 60, reps: 10, completed: true }] }],
+    });
+
+    const all = await getAllWorkouts(env.DB, userId);
+    expect(all).toHaveLength(1);
+    expect(all[0].exercises[0].name).toBe('Press');
   });
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -106,10 +106,91 @@ export async function getAllWorkouts(db: D1Database, userId: string): Promise<Wo
     .bind(userId)
     .all<WorkoutRow>();
 
-  const workouts: Workout[] = [];
+  if (workoutRows.results.length === 0) return [];
 
+  // Batch-fetch all child rows for this user's workouts in 3 queries, then
+  // assemble in memory. The previous implementation called getWorkoutExercises()
+  // per workout — one exercises query + one PRs query each, plus one sets query
+  // per exercise — i.e. an N+1 explosion of hundreds of sequential D1 round
+  // trips for a typical history (~90 workouts × ~5 exercises ≈ 500+ queries).
+  // That made GET /workouts take ~6s. Joining through `workouts` scopes each
+  // child query to this user without a giant IN(...) list, and the result is
+  // byte-for-byte identical to the per-workout assembly below.
+  const exerciseRows = (await db
+    .prepare(
+      `SELECT we.* FROM workout_exercises we
+       JOIN workouts w ON we.workout_id = w.id
+       WHERE w.user_id = ?
+       ORDER BY we.workout_id, we.position`
+    )
+    .bind(userId)
+    .all<WorkoutExerciseRow>()).results;
+
+  const setRows = (await db
+    .prepare(
+      `SELECT s.* FROM sets s
+       JOIN workout_exercises we ON s.workout_exercise_id = we.id
+       JOIN workouts w ON we.workout_id = w.id
+       WHERE w.user_id = ?
+       ORDER BY s.workout_exercise_id, s.position`
+    )
+    .bind(userId)
+    .all<SetRow>()).results;
+
+  const prRows = (await db
+    .prepare('SELECT * FROM personal_records WHERE user_id = ?')
+    .bind(userId)
+    .all<PersonalRecordRow>()).results;
+
+  // Group children by parent id (insertion order preserves the ORDER BY above).
+  const exercisesByWorkout = new Map<string, WorkoutExerciseRow[]>();
+  for (const e of exerciseRows) {
+    const arr = exercisesByWorkout.get(e.workout_id);
+    if (arr) arr.push(e);
+    else exercisesByWorkout.set(e.workout_id, [e]);
+  }
+  const setsByExercise = new Map<string, SetRow[]>();
+  for (const s of setRows) {
+    const arr = setsByExercise.get(s.workout_exercise_id);
+    if (arr) arr.push(s);
+    else setsByExercise.set(s.workout_exercise_id, [s]);
+  }
+  const prsByWorkout = new Map<string, PersonalRecordRow[]>();
+  for (const pr of prRows) {
+    const arr = prsByWorkout.get(pr.workout_id);
+    if (arr) arr.push(pr);
+    else prsByWorkout.set(pr.workout_id, [pr]);
+  }
+
+  const workouts: Workout[] = [];
   for (const row of workoutRows.results) {
-    const exercises = await getWorkoutExercises(db, row.id);
+    const workoutPRs = prsByWorkout.get(row.id) ?? [];
+    const exercises: WorkoutExercise[] = (exercisesByWorkout.get(row.id) ?? []).map((exRow) => {
+      const sets: Set[] = (setsByExercise.get(exRow.id) ?? []).map((s, index) => {
+        // PR match mirrors getWorkoutExercises(): same exercise name, the set's
+        // ordinal position, weight, and reps.
+        const isPR = workoutPRs.some(pr =>
+          pr.exercise_name === exRow.exercise_name &&
+          pr.set_index === index &&
+          pr.weight === s.weight &&
+          pr.reps === s.reps
+        );
+        return {
+          weight: s.weight,
+          reps: s.reps,
+          note: s.note ?? undefined,
+          isPR,
+          completed: s.completed === 1,
+          missed: s.missed === 1,
+        };
+      });
+      return {
+        name: exRow.exercise_name,
+        sets,
+        completed: exRow.completed === 1,
+        notes: exRow.notes ?? undefined,
+      };
+    });
     const targetCategories = row.target_categories
       ? [...new Set((JSON.parse(row.target_categories) as string[]).map(mapToMuscleGroup))]
       : undefined;


### PR DESCRIPTION
**Why `GET /workouts` was slow:** `getAllWorkouts` assembled the history by calling `getWorkoutExercises()` once per workout — one exercises query + one PRs query each, plus one sets query per exercise. For a ~90-workout history that's 500+ sequential D1 round trips. The 225KB / ~6s response was query latency, not bandwidth — and it's what was aborting on slow connections and making the app feel sluggish.

**Fix:** replace the per-workout loop with 3 batched child queries (exercises, sets, PRs), each scoped to the user via a join, then group and assemble in memory. The output is byte-for-byte identical — asserted by a new test comparing `getAllWorkouts` against the per-workout `getWorkout`.

Also adds the first direct test coverage for `getAllWorkouts` (ordering, multi-workout/exercise/set assembly, PR flags, user scoping) — it had none before.

No API or frontend changes; the response shape is unchanged.